### PR TITLE
Update go-code-tester to check for packages with no test files

### DIFF
--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -18,6 +18,10 @@ touch ${COVERAGE_TMPFILE}.count
 check_coverage() {
     while read -r line
     do
+        no_tests=$(echo "$line" | awk '{print $1}')
+        if [ "$no_tests" == "?" ]; then
+            continue
+        fi
         echo "$line" | awk '{print $2, substr($5, 1, length($5)-1)}' | while read pkg cov
         do
             if [ $((${cov%.*} - ${THRESHOLD})) -lt 0 ]; then


### PR DESCRIPTION
# Description
This PR updates the go-code-tester action to not return a failure on a package that does not contain any test files. The `entrypoint` will now check if each line begins with `?` and if so, skip analysis of that line. 

Example false failure:

```
[actions-test]# ./actions/code-coverage/entrypoint.sh 90
?       actions-test/cmd        [no test files]
ok      actions-test/demo       0.022s  coverage: 100.0% of statements
ok      actions-test/test       0.023s  coverage: 100.0% of statements
actions-test/cmd does not meet 90% coverage
```

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|    [#8](https://github.com/dell/common-github-actions/issues/8) go-code-tester returns a failure when no test files exist     | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

This has been manually tested by executing the entrypoint script against a repository that has packages with no test files and verifying that packages without test files are not checked for code coverage.
