### PR TITLE
Change base Dockerfile image used by code-sanitizer scanner

### DIFF
--- a/code-sanitizer/Dockerfile
+++ b/code-sanitizer/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM ubuntu
 
 LABEL "com.github.actions.name"="code-sanitizer"
 LABEL "com.github.actions.description"="Checks for forbidden words and text in the code"
@@ -10,4 +10,4 @@ LABEL version="1.0.0"
 COPY "inclusive-words.forbidden-word-list" "/inclusive-words.forbidden-word-list"
 COPY "entrypoint.sh" "/entrypoint.sh"
 RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["bash", "/entrypoint.sh", "-d"]


### PR DESCRIPTION
# Description

There are two fixes in the PR:

(1) Changed the Docker image to use ubuntu. Other images were tried (like alpine), but there were issues with those. For example, some didn't have bash or others had a version of 'grep' that didn't have the flags that we're using in the scanner script. The ubuntu image seems to be the smallest working Linux image that also allows the scanner script to work as expected.

(2) Changed the ENTRYPOINT spec in the Docker file to reference the "-d" option. Otherwise, the invocation of the scanner wouldn't work as expected when deployed as a GitHub Action.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|  https://github.com/dell/common-github-actions/issues/12  | 

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

The image size is considerably smaller (golang image was close to 900MB):
```
docker images | grep -e code-sanitizer -e ubuntu                                                               
code-sanitizer                                         latest              02e2711a2b1b        13 minutes ago      72.9MB
ubuntu                                                 latest              d70eaf7277ea        4 days ago          72.9MB
```

Run the tests manually against this repo:
```
docker run --rm -it -v "/workspace/common-github-actions":"/usr/local/share" code-sanitizer /usr/local/share | tail


-- Checking for , with a regex of 'blackout|noninclusive word|restrict could be used instead' because
./code-sanitizer/test/non-inclusive/all-words.txt:34:blackout


-- Checking for , with a regex of 'blackouts|noninclusive word|restricts could be used instead' because
./code-sanitizer/test/non-inclusive/all-words.txt:35:blackouts

Total issues found: 50
```