### PR TITLE
[BUG] Code-sanitizer scripting fix

### DIFF
--- a/code-sanitizer/entrypoint.sh
+++ b/code-sanitizer/entrypoint.sh
@@ -4,7 +4,6 @@ SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 DIRECTORY=$(pwd)
 TOTALFOUND=0
 SCRIPTNAME=$(basename "$0")
-OUTPUT=""
 
 cd "${SCRIPTDIR}" || exit
 for file_name in "${SCRIPTDIR}"/*.forbidden-word-list; do
@@ -15,17 +14,12 @@ function usage() {
   echo
   echo "$SCRIPTNAME"
   echo "    -d directory        - Directory to scan, default is the current working directory"
-  echo "    -t output filename  - Write results to a file and stdout"
   exit 1
 }
 
 # output -
 function output() {
-  if [ "${OUTPUT}blank" == "blank" ]; then
-    grep -E -iwRHI --color --line-number --exclude-dir .git --exclude-dir .github --exclude-dir .idea --exclude "*.forbidden-word-list" "${W}" .
-  else
-    grep -E -iwRHI --line-number --exclude-dir .git --exclude-dir .github --exclude-dir .idea --exclude "*.forbidden-word-list" "${W}" . | tee -a ${OUTPUT}
-  fi
+  grep -E -iwRHI --color --line-number --exclude-dir .git --exclude-dir .github --exclude-dir .idea --exclude "*.forbidden-word-list" "${W}" .
 }
 
 # check_for_disallowed_words
@@ -33,7 +27,7 @@ function output() {
 function check_for_disallowed_words() {
   cd "${DIRECTORY}" || exit
   for A in "${DISALLOWEDWORDS[@]}"; do
-    IFS='|' tokens=("$A")
+    IFS='|' tokens=($A)
     W="${tokens[0]}"
     T="${tokens[1]}"
     E="${tokens[2]}"
@@ -53,7 +47,7 @@ function check_for_disallowed_words() {
 
 }
 
-while getopts "t:d:h" opt; do
+while getopts "d:h" opt; do
   case $opt in
   d)
     DIRECTORY="${OPTARG}"
@@ -61,9 +55,6 @@ while getopts "t:d:h" opt; do
   h)
     usage
     exit 0
-    ;;
-  t)
-    OUTPUT="${OPTARG}"
     ;;
   \?)
     echo "Invalid option: -$OPTARG" >&2
@@ -77,10 +68,6 @@ while getopts "t:d:h" opt; do
     ;;
   esac
 done
-
-if [ "${OUTPUT}blank" != "blank" ]; then
-  rm -f "${OUTPUT}"
-fi
 
 check_for_disallowed_words "${BASEDIR}/${SOURCE_CLONE}"
 echo "Total issues found: $TOTALFOUND"


### PR DESCRIPTION
# Description
There's a slight bug with the way that the code-sanitizer entrypoint.sh scanner script scans for bugs. This bit of code has small error:

```
function check_for_disallowed_words() {
  cd "${DIRECTORY}" || exit
  for A in "${DISALLOWEDWORDS[@]}"; do
    IFS='|' tokens=("$A")
    W="${tokens[0]}"
    T="${tokens[1]}"
    E="${tokens[2]}"
```
# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|   https://github.com/dell/common-github-actions/issues/17  | 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Build docker image with the changes, then ran the test with that docker image:

```
[root@:/workspace/common-github-actions/code-sanitizer(bugfix-code-sanitizer-script-bug)]$ git log -n1
commit 7472c2a5d1e2b45f8143885160c46ca631ca1a41 (HEAD -> bugfix-code-sanitizer-script-bug, origin/bugfix-code-sanitizer-script-bug)
Author: Ameer Jabbar <ameer.jabbar@dell.com>
Date:   Wed Oct 28 13:48:20 2020 -0400

    (1) Fix bug with string splitting (2) Remove unnecessary options for script invocation
[root@:/workspace/common-github-actions/code-sanitizer(bugfix-code-sanitizer-script-bug)]$ docker build -t code-sanitizer .Sending build context to Docker daemon  15.87kB
Step 1/10 : FROM ubuntu
 ---> d70eaf7277ea
Step 2/10 : LABEL "com.github.actions.name"="code-sanitizer"
 ---> Using cache
 ---> ae6b682afb1c
Step 3/10 : LABEL "com.github.actions.description"="Checks for forbidden words and text in the code"
 ---> Using cache
 ---> 113a37d906bc
Step 4/10 : LABEL "com.github.actions.icon"="eye"
 ---> Using cache
 ---> 7e7b7b38fd1d
Step 5/10 : LABEL "com.github.actions.color"="gray-dark"
 ---> Using cache
 ---> c6b817ebc85d
Step 6/10 : LABEL version="1.0.0"
 ---> Using cache
 ---> cb429c508419
Step 7/10 : COPY "inclusive-words.forbidden-word-list" "/inclusive-words.forbidden-word-list"
 ---> Using cache
 ---> 2a2efd694ab2
Step 8/10 : COPY "entrypoint.sh" "/entrypoint.sh"
 ---> 5575e0708a5b
Step 9/10 : RUN chmod +x /entrypoint.sh
 ---> Running in 824dc91e10e2
Removing intermediate container 824dc91e10e2
 ---> cd30512ae608
Step 10/10 : ENTRYPOINT ["bash", "/entrypoint.sh", "-d"]
 ---> Running in ad22ae175c95
Removing intermediate container ad22ae175c95
 ---> 22e56bd7c2d5
Successfully built 22e56bd7c2d5
Successfully tagged code-sanitizer:latest
[root@:/workspace/common-github-actions/code-sanitizer(bugfix-code-sanitizer-script-bug)]$ docker run --rm -it -v "$(pwd)":"/usr/local/share" code-sanitizer /usr/local/share

-- Checking for noninclusive word, with a regex of 'master/slave' because primary/secondary could be used instead
./test/non-inclusive/all-words.txt:2:master/slave


-- Checking for noninclusive word, with a regex of 'masters/slaves' because primaries/secondaries could be used instead
./test/non-inclusive/all-words.txt:3:masters/slaves
```