### PR TITLE
The Contributor Covenant badge links to CODE_OF_CONDUCT.md but should…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You may obtain a copy of the License at
 -->
 # Dell GitHub Actions
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](./docs/CODE_OF_CONDUCT.md)
 [![License](https://img.shields.io/github/license/dell/common-github-actions)](LICENSE)
 [![Latest Release](https://img.shields.io/github/v/release/dell/common-github-actions?label=latest&style=flat-square)](https://github.com/dell/common-github-actions/releases)
 


### PR DESCRIPTION
… link to ./docs/CODE_OF_CONDUCT.md

# Description
Contributor Covenant badge link does not work.
The Contributor Covenant badge links to CODE_OF_CONDUCT.md but should link to ./docs/CODE_OF_CONDUCT.md

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|     #27 Contributor Covenant badge link does not work     | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Documentation update. Contributor covenant link is working after the changes is done.

- [x] Documentation update