### PR TITLE
Add a way to go vet in a particular directory

### DIFF
--- a/go-code-formatter-linter-vetter/action.yml
+++ b/go-code-formatter-linter-vetter/action.yml
@@ -5,7 +5,7 @@
 # You may obtain a copy of the License at
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
-name: 'Check Formating, Linting, Vetting'
+name: 'Check Formatting, Linting, Vetting'
 description: 'Runs gofmt, golint, and go vet'
 
 inputs:

--- a/go-code-formatter-linter-vetter/action.yml
+++ b/go-code-formatter-linter-vetter/action.yml
@@ -10,7 +10,11 @@ description: 'Runs gofmt, golint, and go vet'
 
 inputs:
   directories:
-    description: 'Directories to run checks'
+    description: >
+      Directories to run checks. Format is:
+        directories: [--vet-in-dir <VET_DIR>] <DIRS>
+      As shown, you can optionally specify '--vet-in-dir' for cases where the module is
+      defined within a specific directory and you would like to run the 'go vet' there.
     required: true
     default: './...'
 

--- a/go-code-formatter-linter-vetter/entrypoint.sh
+++ b/go-code-formatter-linter-vetter/entrypoint.sh
@@ -13,7 +13,7 @@ VET_IN_DIR=0
 VET_DIR=""
 
 captured_vet_dir=0
-for param in "$@"
+for param in $@
 do
     case $param in
        "--vet-in-dir")


### PR DESCRIPTION
# Description
In this PR, we would like to run the go vet within a specific directory because the go.mod is defined there instead of at the root of the source.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|   #44        | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Manually tested the entrypoint.sh file against a source tree.

Fails without spec:
```
../entrypoint.sh ./...
[*****]/[*****].pb.go:11:2: cannot find package "github.com/golang/protobuf/proto" in any of:
 /usr/local/go/src/github.com/golang/protobuf/proto (from $GOROOT)
 /root/go/src/github.com/golang/protobuf/proto (from $GOPATH)
[*****]/[*****].pb.go:12:2: cannot find package "google.golang.org/grpc" in any of:
 /usr/local/go/src/google.golang.org/grpc (from $GOROOT)
 /root/go/src/google.golang.org/grpc (from $GOPATH)
[*****]/[*****].pb.go:13:2: cannot find package "google.golang.org/grpc/codes" in any of:
 /usr/local/go/src/google.golang.org/grpc/codes (from $GOROOT)
 /root/go/src/google.golang.org/grpc/codes (from $GOPATH)
[*****]/[*****].pb.go:14:2: cannot find package "google.golang.org/grpc/status" in any of:
 /usr/local/go/src/google.golang.org/grpc/status (from $GOROOT)
 /root/go/src/google.golang.org/grpc/status (from $GOPATH)
[*****]/[*****].pb.go:15:2: cannot find package "google.golang.org/protobuf/reflect/protoreflect" in any of:
 /usr/local/go/src/google.golang.org/protobuf/reflect/protoreflect (from $GOROOT)
 /root/go/src/google.golang.org/protobuf/reflect/protoreflect (from $GOPATH)
[*****]/[*****].pb.go:16:2: cannot find package "google.golang.org/protobuf/runtime/protoimpl" in any of:
 /usr/local/go/src/google.golang.org/protobuf/runtime/protoimpl (from $GOROOT)
 /root/go/src/google.golang.org/protobuf/runtime/protoimpl (from $GOPATH)
=== Finished
=== Linting...
=== Finished
Vetting checks failed!
```

Works with spec:
```
../entrypoint.sh --vet-in-dir [redacted] ./...
=== Checking format...
=== Finished
=== Vetting...
=== Finished
/workspace/dell-csi-extensions
=== Linting...
=== Finished
```