### PR TITLE
bugfix-46: Bumps Go versions to 1.16

### DIFF
--- a/go-code-formatter-linter-vetter/Dockerfile
+++ b/go-code-formatter-linter-vetter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 LABEL "com.github.actions.name"="go-code-formatter-linter-vetter"
 LABEL "com.github.actions.description"="Checks for formatting, linting, and vetting issues"

--- a/go-code-tester/Dockerfile
+++ b/go-code-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 LABEL "com.github.actions.name"="go-code-tester"
 LABEL "com.github.actions.description"="Runs unit tests and verifies code coverage per package"


### PR DESCRIPTION
# Description
Bumps the Go versions to 1.16.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|  #46 | 

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
