### PR TITLE
Add an optional skip-list parameter for code coverage

### DIFF
--- a/go-code-tester/README.md
+++ b/go-code-tester/README.md
@@ -29,6 +29,6 @@ jobs:
           skip-list: "this/pkg1,this/pkg2"
 ```
 
-The `threshold` for the Action is a coverage percentage threshold that every pakcage must meet. The default `threshold` is 90.
+The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
 
 The `skip-list` is an optional parameter. It should be a comma delimited string of package names to skip for the testing coverage criteria.

--- a/go-code-tester/README.md
+++ b/go-code-tester/README.md
@@ -25,6 +25,10 @@ jobs:
         uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: 90
+          # Optional parameter to skip certain packages
+          skip-list: "this/pkg1,this/pkg2"
 ```
 
 The `threshold` for the Action is a coverage percentage threshold that every pakcage must meet. The default `threshold` is 90.
+
+The `skip-list` is an optional parameter. It should be a comma delimited string of package names to skip for the testing coverage criteria.

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -12,12 +12,16 @@ inputs:
     description: 'Code coverage threshold for packages'
     required: true
     default: 90
+  skip-list:
+    description: 'A comma delimited list of pkg names to skip for coverage constraint'
+    required: false
+    default: ""
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.threshold }}
-
+    - ${{ inputs.skip-list }}
 branding:
   icon: 'shield'
   color: 'blue'

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -9,6 +9,31 @@
 #  http://www.apache.org/licenses/LICENSE-2.0
 
 THRESHOLD=$1
+SKIP_LIST=$2
+pkg_skip_list=
+
+# Second parameter is a comma delimited list of
+# Go package names that should have the coverage
+# criteria applied against
+if [ "${SKIP_LIST}"x != "x" ]; then
+  # Save the current IFS
+  p_IFS=$IFS
+  IFS=','
+  read -r -a pkg_skip_list <<<"$SKIP_LIST"
+  echo "There are ${#pkg_skip_list[*]} packages to skip"
+  # Reset to the saved value
+  IFS=$p_IFS
+fi
+
+is_in_skip_list() {
+  name=$1
+  for val in "${pkg_skip_list[@]}"; do
+    if [ "$val" = "$name" ]; then
+      return 1
+    fi
+  done
+  return 0
+}
 
 go clean -testcache
 
@@ -33,8 +58,13 @@ check_coverage() {
         echo "$line" | awk '{print $2, substr($5, 1, length($5)-1)}' | while read pkg cov
         do
             if [ $((${cov%.*} - ${THRESHOLD})) -lt 0 ]; then
-                echo "$pkg" does not meet "$THRESHOLD"% coverage | tee $COVERAGE_TMPFILE
-                cat $COVERAGE_TMPFILE | wc -l > $COVERAGE_TMPFILE_COUNT
+                is_in_skip_list $pkg
+                if [ $? -eq 0 ]; then
+                  echo "$pkg" does not meet "$THRESHOLD"% coverage | tee $COVERAGE_TMPFILE
+                  cat $COVERAGE_TMPFILE | wc -l > $COVERAGE_TMPFILE_COUNT
+                else
+                  echo "$pkg" "$cov"% is less than the "$THRESHOLD"% threshold, but it is in the skip list
+                fi
             fi 
         done
     done <<< "${TEST_OUTPUT}"


### PR DESCRIPTION
# Description
I want to be able to have the go tester not apply the code coverage threshold against certain packages. I have code that has tests, which is only used for integration testing. It is has 80% coverage, but effort needed to get it above the threshold is not worthwhile.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|      #48    | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Ran the tests manually:

#### With skip-list
```
[root@:/workspace/karavi-resiliency(integration-tests)]$ bash ../common-github-actions/go-code-tester/entrypoint.sh 90 "podmon/test/ssh3,podmon/test/ssh2,podmon/test/ssh"
There are 3 packages to skip
ok      podmon/cmd/podmon       0.257s  coverage: 93.9% of statements
?       podmon/internal/csiapi  [no test files]
?       podmon/internal/k8sapi  [no test files]
ok      podmon/internal/monitor 5.133s  coverage: 92.4% of statements
?       podmon/internal/utils   [no test files]
?       podmon/test/podmontest  [no test files]
ok      podmon/test/ssh 2.053s  coverage: 82.5% of statements
?       podmon/test/ssh/cli     [no test files]
?       podmon/test/ssh/mocks   [no test files]
podmon/test/ssh 82.5% is less than 90% threshold, but it is in the skip list
```

#### Without skip-list
```
[root@:/workspace/karavi-resiliency(integration-tests)]$ bash ../common-github-actions/go-code-tester/entrypoint.sh 90
ok      podmon/cmd/podmon       0.238s  coverage: 93.9% of statements
?       podmon/internal/csiapi  [no test files]
?       podmon/internal/k8sapi  [no test files]
ok      podmon/internal/monitor 5.166s  coverage: 92.4% of statements
?       podmon/internal/utils   [no test files]
?       podmon/test/podmontest  [no test files]
ok      podmon/test/ssh 2.068s  coverage: 82.5% of statements
?       podmon/test/ssh/cli     [no test files]
?       podmon/test/ssh/mocks   [no test files]
podmon/test/ssh does not meet 90% coverage
```
