### PR TITLE
Use freshclam for getting latest CVD

### DIFF
--- a/malware-scanner/Dockerfile
+++ b/malware-scanner/Dockerfile
@@ -9,9 +9,8 @@ LABEL version="1.0.0"
 
 # Install clamav
 RUN apt-get update
-RUN apt-get -y install clamav clamav-daemon wget systemd
-RUN wget --no-verbose --no-check-certificate https://database.clamav.net/daily.cvd
-RUN cp daily.cvd /var/lib/clamav/daily.cvd
+RUN apt-get -y install clamav clamav-daemon wget systemd clamav-freshclam
+RUN freshclam
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
# Description
We are having failures with the malware scanner Docker build as it was using 'wget' to pull the daily.cvd file. This is explicitly denied on the clamav.net site, https://www.clamav.net/documents/freshclam-faq:

> If you are receiving a 403, 503, or 1020 error codes when downloading from Cloudflare, then you are either explicitly blocked, using an EOL’ed version of ClamAV or you are downloading incorrectly. After checking that you are using a current version of ClamAV, please discontinue whatever method of download you are using and immediately move to using either FreshClam or cvdupdate. These are the two supported methods for downloading AV updates from ClamAV. All other methods may be rate limited, or blocked at our discretion. Use of Wget, Curl, or other command line tools that are scripted are explicitly denied.
> 
> If you are receiving a 429, that means you are rate limited. You’re download too fast or too much. Please use Freshclam or cvdupdate. If you are using a shared hosting provider, like Amazon AWS, Google Cloud Computing, Oracle, Azure, etc, you will most likely be rate limted, however cvdupdate should handle this gracefully.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|    #50       | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

This PR has the malware scanner run against itself. The following output shows that it's running freshclam:

```console
  Step 9/12 : RUN freshclam
   ---> Running in a3ac721ea1d7
  Wed Mar 10 20:14:29 2021 -> ClamAV update process started at Wed Mar 10 20:14:29 2021
  Wed Mar 10 20:14:29 2021 -> daily database available for download (remote version: 26104)
  Wed Mar 10 20:14:32 2021 -> Testing database: '/var/lib/clamav/tmp.2e5f9/clamav-0f4937ddcdeab07b036a5d31816e94c1.tmp-daily.cvd' ...
  Wed Mar 10 20:14:42 2021 -> Database test passed.
  Wed Mar 10 20:14:42 2021 -> daily.cvd updated (version: 26104, sigs: 3958880, f-level: 63, builder: raynman)
  Wed Mar 10 20:14:42 2021 -> main database available for download (remote version: 59)
  Wed Mar 10 20:14:46 2021 -> Testing database: '/var/lib/clamav/tmp.2e5f9/clamav-f8a3faf595dbf7af2fa4c5d5dc3bfa9c.tmp-main.cvd' ...
  Wed Mar 10 20:14:52 2021 -> Database test passed.
  Wed Mar 10 20:14:52 2021 -> main.cvd updated (version: 59, sigs: 4564902, f-level: 60, builder: sigmgr)
  Wed Mar 10 20:14:52 2021 -> bytecode database available for download (remote version: 333)
  Wed Mar 10 20:14:52 2021 -> Testing database: '/var/lib/clamav/tmp.2e5f9/clamav-55fe7831e6b377d21144243b672ce6be.tmp-bytecode.cvd' ...
  Wed Mar 10 20:14:52 2021 -> Database test passed.
  Wed Mar 10 20:14:52 2021 -> bytecode.cvd updated (version: 333, sigs: 92, f-level: 63, builder: awillia2)
  Wed Mar 10 20:14:52 2021 -> ^Clamd was NOT notified: Can't connect to clamd through /var/run/clamav/clamd.ctl: No such file or directory
  Removing intermediate container a3ac721ea1d7
   ---> 5915eaca8228
  Step 10/12 : COPY "entrypoint.sh" "/entrypoint.sh"
   ---> 3a12badfb487
  Step 11/12 : RUN chmod +x /entrypoint.sh
   ---> Running in 2e0802a46a91
  Removing intermediate container 2e0802a46a91
   ---> abee0350d1a6
  Step 12/12 : ENTRYPOINT ["/entrypoint.sh"]
   ---> Running in c673f32dc625
  Removing intermediate container c673f32dc625
   ---> 54b881169e50
  Successfully built 54b881169e50
  Successfully tagged 5588e4:8f872b5e14505c45ee81efdfc5a58fc7
/usr/bin/docker run --name e48f872b5e14505c45ee81efdfc5a58fc7_37170f --label 5588e4 --workdir /github/workspace --rm -e INPUT_DIRECTORIES -e INPUT_OPTIONS -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/common-github-actions/common-github-actions":"/github/workspace" 5588e4:8f872b5e14505c45ee81efdfc5a58fc7  "." "-rf"
=== Scanning working and .git directories...
=== Finished
=== No Malware Found!
```