### PR TITLE
Fix csi driver unit tests

### DIFF
--- a/go-code-tester/README.md
+++ b/go-code-tester/README.md
@@ -25,10 +25,13 @@ jobs:
         uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: 90
+          test-folder: "."
           # Optional parameter to skip certain packages
           skip-list: "this/pkg1,this/pkg2"
 ```
 
 The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
+
+The `test-folder` is for specifying what folder to run the test command in. The default value is the current folder, `"."`
 
 The `skip-list` is an optional parameter. It should be a comma delimited string of package names to skip for the testing coverage criteria.

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Code coverage threshold for packages'
     required: true
     default: 90
+  test-folder:
+    description: 'Folder the test is run in'
+    required: true
+    default: "."
   skip-list:
     description: 'A comma delimited list of pkg names to skip for coverage constraint'
     required: false

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: 90
   test-folder:
     description: 'Folder the test is run in'
-    required: true
+    required: false
     default: "."
   skip-list:
     description: 'A comma delimited list of pkg names to skip for coverage constraint'

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -25,6 +25,7 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.threshold }}
+    - ${{ inputs.test-folder }}
     - ${{ inputs.skip-list }}
 branding:
   icon: 'shield'

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -38,7 +38,7 @@ is_in_skip_list() {
 
 go clean -testcache
 
-TEST_OUTPUT=$(cd ${TEST_FOLDER} && go test -short -count=1 -race -cover ./... | tee /dev/stderr; exit ${PIPESTATUS[0]})
+TEST_OUTPUT=$(cd ${TEST_FOLDER} && go test -v -short -count=1 -race -cover ./... | tee /dev/stderr; exit ${PIPESTATUS[0]})
 TEST_RETURN_CODE=$?
 
 if [ "${TEST_RETURN_CODE}" != "0" ]; then

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -9,7 +9,8 @@
 #  http://www.apache.org/licenses/LICENSE-2.0
 
 THRESHOLD=$1
-SKIP_LIST=$2
+TEST_FOLDER=$2
+SKIP_LIST=$3
 pkg_skip_list=
 
 # Second parameter is a comma delimited list of
@@ -37,7 +38,7 @@ is_in_skip_list() {
 
 go clean -testcache
 
-TEST_OUTPUT=$(go test -short -count=1 -race -cover ./... | tee /dev/stderr; exit ${PIPESTATUS[0]})
+TEST_OUTPUT=$(cd ${TEST_FOLDER} && go test -short -count=1 -race -cover ./... | tee /dev/stderr; exit ${PIPESTATUS[0]})
 TEST_RETURN_CODE=$?
 
 if [ "${TEST_RETURN_CODE}" != "0" ]; then


### PR DESCRIPTION
# Description
The objective of this PR is to prevent the unit test action from executing integration tests.  The unit tests need to be in a sub-directory to avoid having both the unit and integration tests. To accomplish this, I added a "test-folder" parameter into the action that is required and has the default value of `"."`. This follows the precedent set by other actions in this project and will allow the the action to run unit tests without triggering integration tests as well.

One thing to note is that this may break tests for people already using this repo, since they will now have to provide three parameters instead of two.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|          | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran against multiple CSI repositories to confirm that it works.
