### PR TITLE
Remove verbose flag to fix the checking of code coverage

### DIFF
--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -38,7 +38,7 @@ is_in_skip_list() {
 
 go clean -testcache
 
-TEST_OUTPUT=$(cd ${TEST_FOLDER} && go test -v -short -count=1 -race -cover ./... | tee /dev/stderr; exit ${PIPESTATUS[0]})
+TEST_OUTPUT=$(cd ${TEST_FOLDER} && go test -short -count=1 -race -cover ./... | tee /dev/stderr; exit ${PIPESTATUS[0]})
 TEST_RETURN_CODE=$?
 
 if [ "${TEST_RETURN_CODE}" != "0" ]; then


### PR DESCRIPTION
# Description
Remove verbose flag to fix the checking of code coverage. When passing the `-v` flag, additional lines are output which is failing the checks for code coverage per package. (see failed run here: https://github.com/dell/csm-metrics-powerstore/runs/4506519529?check_suite_focus=true).

This reverts the change made in this PR: https://github.com/dell/common-github-actions/pull/53/files#diff-6ddf9683442f306bc1d26e940de97a2b98107bbe14160dc6fac57d375d19553eR41

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|          | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Compared verbose vs non-verbose output of the tests
