### PR TITLE
Fix tests passing with insufficient coverage

### DIFF
--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -24,11 +24,15 @@ if [ "${TEST_RETURN_CODE}" != "0" ]; then
   exit 1
 fi
 
-# Put skip list in format that will work for grep and into format that is human-readable
-SKIP_LIST_FOR_GREP=${SKIP_LIST//[,]/ -e }
-SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
-
-echo "skipping the following packages: $SKIP_LIST_FOR_ECHO"
+if [ -z "$SKIP_LIST" ]
+then
+  echo "No packages in skip-list"
+else
+  # Put skip list in format that will work for grep and into format that is human-readable
+  SKIP_LIST_FOR_GREP=${SKIP_LIST//[,]/ -e }
+  SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
+  echo "skipping the following packages: $SKIP_LIST_FOR_ECHO"
+fi
 
 FAIL=0
 check_coverage() {
@@ -44,7 +48,7 @@ check_coverage() {
   return 0
 }
 
-if [ -z "$SKIP_LIST_FOR_GREP" ]; then
+if [ -z "$SKIP_LIST" ]; then
   # If there is no skip-list, just search for cases where the word coverage is preceded by whitespace. We want the space because
   # this distinguishes between the final coverage report and the intermediate coverage printouts that happen earlier in the output
   while read pkg cov;

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -50,18 +50,18 @@ check_coverage() {
 if [ -z "$SKIP_LIST_FOR_GREP" ]; then
   # If there is no skip-list, just search for cases where the word coverage is preceded by whitespace. We want the space because
   # this distinguishes between the final coverage report and the intermediate coverage printouts that happen earlier in the output
-  cat ~/run.log | grep -e "\scoverage" | awk '{print $2, substr($5, 1, length($5)-1)}' | while read pkg cov;
+  while read pkg cov;
   do
     check_coverage $pkg $cov
     echo "FAIL is ${FAIL}"
-  done < input.data
+  done <<< $(cat ~/run.log | grep -e "\scoverage" | awk '{print $2, substr($5, 1, length($5)-1)}')
 else
   # this is the same as the above, except it includes a filter that gets rid of all the packages that appear in the skip-list
-  cat ~/run.log | grep -e "\scoverage" | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}' | while read pkg cov;
+  while read pkg cov;
   do
     check_coverage $pkg $cov
     echo "FAIL is ${FAIL}"
-  done < input.data
+  done <<< $(cat ~/run.log | grep -e "\scoverage" | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}')
 fi
 
 echo "FAIL is ${FAIL}"

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -16,7 +16,7 @@ pkg_skip_list=
 go clean -testcache
 
 cd ${TEST_FOLDER}
-go test -v -short -race -count=1 -cover ./... > ~/run.log
+go test -v -short -count=1 -cover ./... > ~/run.log
 TEST_RETURN_CODE=$?
 cat ~/run.log
 if [ "${TEST_RETURN_CODE}" != "0" ]; then

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -31,6 +31,8 @@ SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
 echo "skipping the following packages: $SKIP_LIST_FOR_ECHO"
 
 FAIL=0
+echo "FAIL is ${FAIL}"
+
 check_coverage() {
   pkg=$1
   cov=$2
@@ -51,12 +53,14 @@ if [ -z "$SKIP_LIST_FOR_GREP" ]; then
   cat ~/run.log | grep -e "\scoverage" | awk '{print $2, substr($5, 1, length($5)-1)}' | while read pkg cov;
   do
     check_coverage $pkg $cov
+    echo "FAIL is ${FAIL}"
   done
 else
   # this is the same as the above, except it includes a filter that gets rid of all the packages that appear in the skip-list
   cat ~/run.log | grep -e "\scoverage" | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}' | while read pkg cov;
   do
     check_coverage $pkg $cov
+    echo "FAIL is ${FAIL}"
   done
 fi
 

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -31,7 +31,6 @@ SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
 echo "skipping the following packages: $SKIP_LIST_FOR_ECHO"
 
 FAIL=0
-echo "FAIL is ${FAIL}"
 
 check_coverage() {
   pkg=$1
@@ -39,7 +38,6 @@ check_coverage() {
   if [[ ${THRESHOLD} > ${cov%.*} ]]; then
      echo "FAIL: coverage for package $pkg is ${cov}%, lower than ${THRESHOLD}%"
      FAIL=1
-     echo "FAIL is ${FAIL}"
   else
      echo "PASS: coverage for package $pkg is ${cov}%, not lower than ${THRESHOLD}%"
   fi
@@ -53,17 +51,14 @@ if [ -z "$SKIP_LIST_FOR_GREP" ]; then
   while read pkg cov;
   do
     check_coverage $pkg $cov
-    echo "FAIL is ${FAIL}"
   done <<< $(cat ~/run.log | grep -e "\scoverage" | awk '{print $2, substr($5, 1, length($5)-1)}')
 else
   # this is the same as the above, except it includes a filter that gets rid of all the packages that appear in the skip-list
   while read pkg cov;
   do
     check_coverage $pkg $cov
-    echo "FAIL is ${FAIL}"
   done <<< $(cat ~/run.log | grep -e "\scoverage" | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}')
 fi
 
-echo "FAIL is ${FAIL}"
 exit ${FAIL}
 

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -16,7 +16,7 @@ pkg_skip_list=
 go clean -testcache
 
 cd ${TEST_FOLDER}
-go test -v -short -count=1 -cover ./... > ~/run.log
+go test -v -short -race -count=1 -cover ./... > ~/run.log
 TEST_RETURN_CODE=$?
 cat ~/run.log
 if [ "${TEST_RETURN_CODE}" != "0" ]; then

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -59,5 +59,6 @@ else
   done
 fi
 
+echo ${FAIL}
 exit ${FAIL}
 

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -54,14 +54,14 @@ if [ -z "$SKIP_LIST_FOR_GREP" ]; then
   do
     check_coverage $pkg $cov
     echo "FAIL is ${FAIL}"
-  done
+  done < input.data
 else
   # this is the same as the above, except it includes a filter that gets rid of all the packages that appear in the skip-list
   cat ~/run.log | grep -e "\scoverage" | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}' | while read pkg cov;
   do
     check_coverage $pkg $cov
     echo "FAIL is ${FAIL}"
-  done
+  done < input.data
 fi
 
 echo "FAIL is ${FAIL}"

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -35,10 +35,11 @@ check_coverage() {
   pkg=$1
   cov=$2
   if [[ ${THRESHOLD} > ${cov%.*} ]]; then
-     echo "FAIL: coverage for package $pkg is ${cov}%, lower than 90%"
+     echo "FAIL: coverage for package $pkg is ${cov}%, lower than ${THRESHOLD}%"
      FAIL=1
+     echo "FAIL is ${FAIL}"
   else
-     echo "PASS: coverage for package $pkg is ${cov}%, greater than 90%"
+     echo "PASS: coverage for package $pkg is ${cov}%, not lower than ${THRESHOLD}%"
   fi
 
   return 0
@@ -59,6 +60,6 @@ else
   done
 fi
 
-echo ${FAIL}
+echo "FAIL is ${FAIL}"
 exit ${FAIL}
 

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -31,7 +31,6 @@ SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
 echo "skipping the following packages: $SKIP_LIST_FOR_ECHO"
 
 FAIL=0
-
 check_coverage() {
   pkg=$1
   cov=$2

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -16,9 +16,9 @@ pkg_skip_list=
 go clean -testcache
 
 cd ${TEST_FOLDER}
-go test -v -short -race -count=1 -cover ./... > run.log
+go test -v -short -race -count=1 -cover ./... > ~/run.log
 TEST_RETURN_CODE=$?
-cat run.log
+cat ~/run.log
 if [ "${TEST_RETURN_CODE}" != "0" ]; then
   echo "test failed with return code $TEST_RETURN_CODE"
   exit 1


### PR DESCRIPTION
# Description
This PR does two things:
1) Fixes an issue with tests passing even when the coverage is too low
2) Improves the skip-list printout to only print the skip-list when it exists

# Issues
None

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Ran the actions in a repo with sufficient coverage, in a PR with insufficient coverage, and in a repo with a skip-list
