### PR TITLE
[go-code-formatter-linter-vetter] Removed deprecated insecure flag and base off of go v1.17

### DIFF
--- a/go-code-formatter-linter-vetter/Dockerfile
+++ b/go-code-formatter-linter-vetter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.17
 
 LABEL "com.github.actions.name"="go-code-formatter-linter-vetter"
 LABEL "com.github.actions.description"="Checks for formatting, linting, and vetting issues"

--- a/go-code-formatter-linter-vetter/entrypoint.sh
+++ b/go-code-formatter-linter-vetter/entrypoint.sh
@@ -86,7 +86,7 @@ fi
 
 echo === Linting...
 (command -v golint >/dev/null 2>&1 \
-    || GO111MODULE=off go get -insecure -u golang.org/x/lint/golint) \
+    || GO111MODULE=off go get -u golang.org/x/lint/golint) \
     && golint --set_exit_status ${CHECK_DIRS}
 LINT_RETURN_CODE=$?
 echo === Finished


### PR DESCRIPTION
# Description
With CSM modules updating to go v1.17 the Github actions that run on those PRs have issues when using an older go version.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|     N/A     | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Manually ran the entrypoint.sh script against my 1.17 branch of a couple of CSM modules that are being updated
