### PR TITLE
Go code tester coverage check fix

### DIFF
--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -38,7 +38,7 @@ FAIL=0
 check_coverage() {
   pkg=$1
   cov=$2
-  if [[ ${THRESHOLD} > ${cov%.*} ]]; then
+  if [[ ${THRESHOLD} -gt ${cov%.*} ]]; then
      echo "FAIL: coverage for package $pkg is ${cov}%, lower than ${THRESHOLD}%"
      FAIL=1
   else


### PR DESCRIPTION
# Description
The code coverage percentage check in the go-code-tester script does not correctly do the comparison as seen [here ](https://github.com/dell/karavi-topology/runs/5145579251?check_suite_focus=true#step:4:154)(100% coverage is seen as less than the 90% threshold).

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|    N/A      | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Running the two commands in a terminal exemplifies the comparison issue:
```
➜  $ if [[ 90 -gt 100 ]]; then
     echo "FAIL: coverage for package $pkg is ${cov}%, lower than ${THRESHOLD}%"
     FAIL=1

fi
➜  $ if [[ 90 > 100 ]]; then
     echo "FAIL: coverage for package $pkg is ${cov}%, lower than ${THRESHOLD}%"
     FAIL=1
fi
FAIL: coverage for package  is %, lower than %
```
