### PR TITLE
Gosec local action

### DIFF
--- a/go-code-formatter-linter-vetter/Dockerfile
+++ b/go-code-formatter-linter-vetter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 LABEL "com.github.actions.name"="go-code-formatter-linter-vetter"
 LABEL "com.github.actions.description"="Checks for formatting, linting, and vetting issues"

--- a/go-code-tester/Dockerfile
+++ b/go-code-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 LABEL "com.github.actions.name"="go-code-tester"
 LABEL "com.github.actions.description"="Runs unit tests and verifies code coverage per package"

--- a/gosec-runner/Dockerfile
+++ b/gosec-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.18
 
 LABEL "com.github.actions.name"="gosec-runner"
 LABEL "com.github.actions.description"="Runs gosec"

--- a/gosec-runner/Dockerfile
+++ b/gosec-runner/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.17
+
+LABEL "com.github.actions.name"="go-code-tester"
+LABEL "com.github.actions.description"="Runs unit tests and verifies code coverage per package"
+LABEL "com.github.actions.icon"="eye"
+LABEL "com.github.actions.color"="gray-dark"
+
+LABEL version="1.0.0"
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/gosec-runner/Dockerfile
+++ b/gosec-runner/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.17
 
-LABEL "com.github.actions.name"="go-code-tester"
-LABEL "com.github.actions.description"="Runs unit tests and verifies code coverage per package"
+LABEL "com.github.actions.name"="gosec-runner"
+LABEL "com.github.actions.description"="Runs gosec"
 LABEL "com.github.actions.icon"="eye"
 LABEL "com.github.actions.color"="gray-dark"
 

--- a/gosec-runner/README.md
+++ b/gosec-runner/README.md
@@ -1,0 +1,37 @@
+# Go Code Tester GitHub Action
+This GitHub Action can be used to run Go unit tests and check that code coverage per package meets a threshold.
+
+To enable this Action, you can create a .yml file under your repo's .github/workflows directory. 
+Simple example:
+
+```
+name: Code Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    name: Run Go unit tests and check package coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Run unit tests and check package coverage
+        uses: dell/common-github-actions/go-code-tester@main
+        with:
+          threshold: 90
+          test-folder: "."
+          # Optional parameter to skip certain packages
+          skip-list: "this/pkg1,this/pkg2"
+```
+
+The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
+
+The `test-folder` is for specifying what folder to run the test command in. The default value is the current folder, `"."`
+
+The `skip-list` is an optional parameter. It should be a comma delimited string of package names to skip for the testing coverage criteria.

--- a/gosec-runner/README.md
+++ b/gosec-runner/README.md
@@ -30,6 +30,9 @@ jobs:
 ```
 
 Arguments described below -- all are optional:
+
 `directories` specifies what directory/directories gosec will run in -- the default `./...` specifies the current folder and all subfolders.
+
 `excludes` is used to give a comma-delimited list of gosec excludes (using the `-excludes=` option in gosec). By default, there are no excludes.
+
 `exclude-dir` specifies a directory to skip in the gosec check (using the `-exclude-dir=` option in gosec).

--- a/gosec-runner/README.md
+++ b/gosec-runner/README.md
@@ -1,11 +1,11 @@
-# Go Code Tester GitHub Action
-This GitHub Action can be used to run Go unit tests and check that code coverage per package meets a threshold.
+# Gosec Runner GitHub Action
+This GitHub Action can be used to run gosec on a particular package.
 
 To enable this Action, you can create a .yml file under your repo's .github/workflows directory. 
 Simple example:
 
 ```
-name: Code Test
+name: Gosec runner
 
 on:
   push:
@@ -16,22 +16,20 @@ on:
 jobs:
 
   build:
-    name: Run Go unit tests and check package coverage
+    name: Run gosec to check for security vulnerabilities
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
       - name: Run unit tests and check package coverage
-        uses: dell/common-github-actions/go-code-tester@main
+        uses: dell/common-github-actions/gosec-runner@main
         with:
-          threshold: 90
-          test-folder: "."
-          # Optional parameter to skip certain packages
-          skip-list: "this/pkg1,this/pkg2"
+          directories: "./..."
+          excludes: "G108,G402"
+          exclude-dir: "csireverseproxy"
 ```
 
-The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
-
-The `test-folder` is for specifying what folder to run the test command in. The default value is the current folder, `"."`
-
-The `skip-list` is an optional parameter. It should be a comma delimited string of package names to skip for the testing coverage criteria.
+Arguments described below -- all are optional:
+`directories` specifies what directory/directories gosec will run in -- the default `./...` specifies the current folder and all subfolders.
+`excludes` is used to give a comma-delimited list of gosec excludes (using the `-excludes=` option in gosec). By default, there are no excludes.
+`exclude-dir` specifies a directory to skip in the gosec check (using the `-exclude-dir=` option in gosec).

--- a/gosec-runner/README.md
+++ b/gosec-runner/README.md
@@ -16,12 +16,12 @@ on:
 jobs:
 
   build:
-    name: Run gosec to check for security vulnerabilities
+    name: Run gosec
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
-      - name: Run unit tests and check package coverage
+      - name: Run gosec to check for security vulnerabilities
         uses: dell/common-github-actions/gosec-runner@main
         with:
           directories: "./..."

--- a/gosec-runner/action.yml
+++ b/gosec-runner/action.yml
@@ -5,28 +5,27 @@
 # You may obtain a copy of the License at
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
-name: 'Go Tester'
-description: 'Runs unit tests and verifies code coverage per package'
+name: 'Run gosec'
+description: 'Runs gosec'
+
 inputs:
-  threshold:
-    description: 'Code coverage threshold for packages'
-    required: true
-    default: 90
-  test-folder:
-    description: 'Folder the test is run in'
+  directories:
+    description: >
+      Directories to run gosec. Default is './...'
     required: false
-    default: "."
-  skip-list:
-    description: 'A comma delimited list of pkg names to skip for coverage constraint'
+    default: './...'
+  excludes:
+    description: 'exclude arguments to run with gosec'
     required: false
     default: ""
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.threshold }}
-    - ${{ inputs.test-folder }}
-    - ${{ inputs.skip-list }}
+    - ${{ inputs.directories }}
+    - ${{ inputs.excludes }}
+
 branding:
   icon: 'shield'
   color: 'blue'

--- a/gosec-runner/action.yml
+++ b/gosec-runner/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'Exclude arguments to run with gosec. List them as such: G304,G208,G215'
     required: false
     default: ""
+  exclude-dir:
+    description: 'Name of directory to be excluded with exclude-dir option'
+    required: false
+    default: ""
 
 runs:
   using: 'docker'

--- a/gosec-runner/action.yml
+++ b/gosec-runner/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: './...'
   excludes:
-    description: 'Exclude arguments to run with gosec. List them as such: G304,G208,G215'
+    description: 'Exclude arguments to run with gosec. List them as such: G108,G402,G307'
     required: false
     default: ""
   exclude-dir:

--- a/gosec-runner/action.yml
+++ b/gosec-runner/action.yml
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+name: 'Go Tester'
+description: 'Runs unit tests and verifies code coverage per package'
+inputs:
+  threshold:
+    description: 'Code coverage threshold for packages'
+    required: true
+    default: 90
+  test-folder:
+    description: 'Folder the test is run in'
+    required: false
+    default: "."
+  skip-list:
+    description: 'A comma delimited list of pkg names to skip for coverage constraint'
+    required: false
+    default: ""
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.threshold }}
+    - ${{ inputs.test-folder }}
+    - ${{ inputs.skip-list }}
+branding:
+  icon: 'shield'
+  color: 'blue'

--- a/gosec-runner/action.yml
+++ b/gosec-runner/action.yml
@@ -10,12 +10,11 @@ description: 'Runs gosec'
 
 inputs:
   directories:
-    description: >
-      Directories to run gosec. Default is './...'
+    description: 'Directories to run gosec in'
     required: false
     default: './...'
   excludes:
-    description: 'exclude arguments to run with gosec'
+    description: 'Exclude arguments to run with gosec. List them as such: G304,G208,G215'
     required: false
     default: ""
 

--- a/gosec-runner/action.yml
+++ b/gosec-runner/action.yml
@@ -28,6 +28,7 @@ runs:
   args:
     - ${{ inputs.directories }}
     - ${{ inputs.excludes }}
+    - ${{ inputs.exclude-dir }}
 
 branding:
   icon: 'shield'

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -14,12 +14,16 @@ EXCLUDES=$2
 GOFLAGS=$GOFLAGS" -buildvcs=false"
 echo "GOFLAGS: $GOFLAGS"
 
-#gosec -exclude=G304 ./...
+sudo apt update -y
+sudo apt install snapd -y
+sudo snap install gosec -y
 
-#TEST_RETURN_CODE=$?
-#if [ "${TEST_RETURN_CODE}" != "0" ]; then
-#  echo "test failed with return code $TEST_RETURN_CODE"
-#  exit 1
-#fi
+gosec -exclude=G304 ./...
 
-#exit 0
+TEST_RETURN_CODE=$?
+if [ "${TEST_RETURN_CODE}" != "0" ]; then
+  echo "test failed with return code $TEST_RETURN_CODE"
+  exit 1
+fi
+
+exit 0

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -16,7 +16,7 @@ echo "GOFLAGS: $GOFLAGS"
 
 apt update -y
 apt install snapd -y
-snap install gosec -y
+snap install gosec
 
 gosec -exclude=G304 ./...
 

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -25,7 +25,7 @@ fi
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
 echo "run gosec command: $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES"
-$(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $DIRECTORIES
+$(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES
 
 TEST_RETURN_CODE=$?
 if [ "${TEST_RETURN_CODE}" != "0" ]; then
@@ -33,5 +33,5 @@ if [ "${TEST_RETURN_CODE}" != "0" ]; then
   exit 1
 fi
 
-echo "gosec ran successfully"
+echo "gosec ran successfully!"
 exit 0

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -19,7 +19,7 @@ fi
 
 if [ -n "$EXCLUDE_DIR" ]
 then
-  EXCLUDE_DIR_FLAG="-exclude=$EXCLUDE_DIR"
+  EXCLUDE_DIR_FLAG="-exclude-dir=$EXCLUDE_DIR"
 fi
 
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -10,16 +10,21 @@
 
 DIRECTORIES=$1
 EXCLUDES=$2
-EXCLUDE_DIR="-exclude-dir=$3"
+EXCLUDE_DIR=$3
 
 if [ -n "$EXCLUDES" ]
 then
   EXCLUDE_FLAG="-exclude=$EXCLUDES"
 fi
 
+if [ -n "$EXCLUDE_DIR" ]
+then
+  EXCLUDE_DIR_FLAG="-exclude=$EXCLUDE_DIR"
+fi
+
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
-echo "run gosec command: $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $DIRECTORIES"
+echo "run gosec command: $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES"
 $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $DIRECTORIES
 
 TEST_RETURN_CODE=$?

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -14,9 +14,9 @@ EXCLUDES=$2
 GOFLAGS=$GOFLAGS" -buildvcs=false"
 echo "GOFLAGS: $GOFLAGS"
 
-sudo apt update -y
-sudo apt install snapd -y
-sudo snap install gosec -y
+apt update -y
+apt install snapd -y
+snap install gosec -y
 
 gosec -exclude=G304 ./...
 

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -8,60 +8,18 @@
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
 
-THRESHOLD=$1
-TEST_FOLDER=$2
-SKIP_LIST=$3
-pkg_skip_list=
+DIRECTORIES=$1
+EXCLUDES=$2
 
-go clean -testcache
+GOFLAGS=$GOFLAGS" -buildvcs=false"
+echo "GOFLAGS: $GOFLAGS"
 
-cd ${TEST_FOLDER}
-go test -v -short -race -count=1 -cover ./... > ~/run.log
+gosec -exclude=G304 ./...
+
 TEST_RETURN_CODE=$?
-cat ~/run.log
 if [ "${TEST_RETURN_CODE}" != "0" ]; then
-  echo "test failed with return code $TEST_RETURN_CODE, not proceeding with coverage check"
+  echo "test failed with return code $TEST_RETURN_CODE"
   exit 1
 fi
 
-if [ -z "$SKIP_LIST" ]
-then
-  echo "No packages in skip-list"
-else
-  # Put skip list in grep-friendly and human-friendly formats
-  SKIP_LIST_FOR_GREP=${SKIP_LIST//[,]/ -e }
-  SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
-  echo "skipping the following packages: $SKIP_LIST_FOR_ECHO"
-fi
-
-FAIL=0
-check_coverage() {
-  pkg=$1
-  cov=$2
-  if [[ ${THRESHOLD} -gt ${cov%.*} ]]; then
-     echo "FAIL: coverage for package $pkg is ${cov}%, lower than ${THRESHOLD}%"
-     FAIL=1
-  else
-     echo "PASS: coverage for package $pkg is ${cov}%, not lower than ${THRESHOLD}%"
-  fi
-
-  return 0
-}
-
-if [ -z "$SKIP_LIST" ]; then
-  # If there is no skip-list, just search for cases where the word coverage is preceded by whitespace. We want the space because
-  # this distinguishes between the final coverage report and the intermediate coverage printouts that happen earlier in the output
-  while read pkg cov;
-  do
-    check_coverage $pkg $cov
-  done <<< $(cat ~/run.log | grep -e "\scoverage" | awk '{print $2, substr($5, 1, length($5)-1)}')
-else
-  # this is the same as the above, except it includes a filter that gets rid of all the packages that appear in the skip-list
-  while read pkg cov;
-  do
-    check_coverage $pkg $cov
-  done <<< $(cat ~/run.log | grep -e "\scoverage" | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}')
-fi
-
-exit ${FAIL}
-
+exit 0

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -29,9 +29,9 @@ $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES
 
 TEST_RETURN_CODE=$?
 if [ "${TEST_RETURN_CODE}" != "0" ]; then
-  echo "gosec failed with return code $TEST_RETURN_CODE"
+  echo "Gosec failed with return code $TEST_RETURN_CODE"
   exit 1
 fi
 
-echo "gosec ran successfully!"
+echo "Gosec ran successfully!"
 exit 0

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+THRESHOLD=$1
+TEST_FOLDER=$2
+SKIP_LIST=$3
+pkg_skip_list=
+
+go clean -testcache
+
+cd ${TEST_FOLDER}
+go test -v -short -race -count=1 -cover ./... > ~/run.log
+TEST_RETURN_CODE=$?
+cat ~/run.log
+if [ "${TEST_RETURN_CODE}" != "0" ]; then
+  echo "test failed with return code $TEST_RETURN_CODE, not proceeding with coverage check"
+  exit 1
+fi
+
+if [ -z "$SKIP_LIST" ]
+then
+  echo "No packages in skip-list"
+else
+  # Put skip list in grep-friendly and human-friendly formats
+  SKIP_LIST_FOR_GREP=${SKIP_LIST//[,]/ -e }
+  SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
+  echo "skipping the following packages: $SKIP_LIST_FOR_ECHO"
+fi
+
+FAIL=0
+check_coverage() {
+  pkg=$1
+  cov=$2
+  if [[ ${THRESHOLD} -gt ${cov%.*} ]]; then
+     echo "FAIL: coverage for package $pkg is ${cov}%, lower than ${THRESHOLD}%"
+     FAIL=1
+  else
+     echo "PASS: coverage for package $pkg is ${cov}%, not lower than ${THRESHOLD}%"
+  fi
+
+  return 0
+}
+
+if [ -z "$SKIP_LIST" ]; then
+  # If there is no skip-list, just search for cases where the word coverage is preceded by whitespace. We want the space because
+  # this distinguishes between the final coverage report and the intermediate coverage printouts that happen earlier in the output
+  while read pkg cov;
+  do
+    check_coverage $pkg $cov
+  done <<< $(cat ~/run.log | grep -e "\scoverage" | awk '{print $2, substr($5, 1, length($5)-1)}')
+else
+  # this is the same as the above, except it includes a filter that gets rid of all the packages that appear in the skip-list
+  while read pkg cov;
+  do
+    check_coverage $pkg $cov
+  done <<< $(cat ~/run.log | grep -e "\scoverage" | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}')
+fi
+
+exit ${FAIL}
+

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -11,7 +11,7 @@
 DIRECTORIES=$1
 EXCLUDES=$2
 
-if [ - "$EXCLUDES" ]
+if [ -n "$EXCLUDES" ]
 then
   EXCLUDE_FLAG="-exclude=$EXCLUDES"
   echo "created exclude flag $EXCLUDE_FLAG"

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -11,8 +11,8 @@
 DIRECTORIES=$1
 EXCLUDES=$2
 
-GOFLAGS=$GOFLAGS" -buildvcs=false"
-echo "GOFLAGS: $GOFLAGS"
+#GOFLAGS=$GOFLAGS" -buildvcs=false"
+#echo "GOFLAGS: $GOFLAGS"
 
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -14,11 +14,9 @@ EXCLUDES=$2
 GOFLAGS=$GOFLAGS" -buildvcs=false"
 echo "GOFLAGS: $GOFLAGS"
 
-apt update -y
-apt install snapd -y
-snap install gosec
+curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
-gosec -exclude=G304 ./...
+$(go env GOPATH)/bin/gosec -exclude=G304 ./...
 
 TEST_RETURN_CODE=$?
 if [ "${TEST_RETURN_CODE}" != "0" ]; then

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -14,6 +14,7 @@ EXCLUDES=$2
 if [ - "$EXCLUDES" ]
 then
   EXCLUDE_FLAG="-exclude=$EXCLUDES"
+  echo "created exclude flag $EXCLUDE_FLAG"
 fi
 
 #GOFLAGS=$GOFLAGS" -buildvcs=false"
@@ -21,6 +22,7 @@ fi
 
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
+echo "run gosec command: $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $DIRECTORIES"
 $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $DIRECTORIES
 
 TEST_RETURN_CODE=$?

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -11,17 +11,23 @@
 DIRECTORIES=$1
 EXCLUDES=$2
 
+if [ - "$EXCLUDES" ]
+then
+  EXCLUDE_FLAG="-exclude=$EXCLUDES"
+fi
+
 #GOFLAGS=$GOFLAGS" -buildvcs=false"
 #echo "GOFLAGS: $GOFLAGS"
 
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
-$(go env GOPATH)/bin/gosec -exclude=G304 ./...
+$(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $DIRECTORIES
 
 TEST_RETURN_CODE=$?
 if [ "${TEST_RETURN_CODE}" != "0" ]; then
-  echo "test failed with return code $TEST_RETURN_CODE"
+  echo "gosec failed with return code $TEST_RETURN_CODE"
   exit 1
 fi
 
+echo "gosec ran successfully"
 exit 0

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -14,12 +14,12 @@ EXCLUDES=$2
 GOFLAGS=$GOFLAGS" -buildvcs=false"
 echo "GOFLAGS: $GOFLAGS"
 
-gosec -exclude=G304 ./...
+#gosec -exclude=G304 ./...
 
-TEST_RETURN_CODE=$?
-if [ "${TEST_RETURN_CODE}" != "0" ]; then
-  echo "test failed with return code $TEST_RETURN_CODE"
-  exit 1
-fi
+#TEST_RETURN_CODE=$?
+#if [ "${TEST_RETURN_CODE}" != "0" ]; then
+#  echo "test failed with return code $TEST_RETURN_CODE"
+#  exit 1
+#fi
 
-exit 0
+#exit 0

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -10,15 +10,12 @@
 
 DIRECTORIES=$1
 EXCLUDES=$2
+EXCLUDE_DIR="-exclude-dir=$3"
 
 if [ -n "$EXCLUDES" ]
 then
   EXCLUDE_FLAG="-exclude=$EXCLUDES"
-  echo "created exclude flag $EXCLUDE_FLAG"
 fi
-
-#GOFLAGS=$GOFLAGS" -buildvcs=false"
-#echo "GOFLAGS: $GOFLAGS"
 
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
 


### PR DESCRIPTION
# Description
This PR creates a local action for running gosec that resolves the issue we have been having with the gosec action failing in the drivers. This action runs a script that grabs the latest gosec and runs it on the package, and gives us a lot more flexibility in debugging/adding flags/environment variables etc.

Additionally, the go actions are updated from go 1.17 to 1.18.
# Issues
List the issues impacted by this PR:
| Issue ID |
| -------- |
|          | 

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Ran the action in csi-powerflex and csi-powermax, results linked here:

https://github.com/dell/csi-powerflex/runs/7328366770?check_suite_focus=true

https://github.com/dell/csi-powermax/runs/7328471223?check_suite_focus=true