### PR TITLE
Fix gosec-runner error - crit unable to find 'latest'

### DIFF
--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -22,7 +22,7 @@ then
   EXCLUDE_DIR_FLAG="-exclude-dir=$EXCLUDE_DIR"
 fi
 
-curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 echo "run gosec command: $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES"
 $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES


### PR DESCRIPTION
# Description
We are seeing error - "_securego/gosec crit unable to find 'latest' - use 'latest' or see https://github.com/securego/gosec/releases for details_" in gosec-runner. 
I have made necessary changes in gosec-runner to align with the latest changes in install script of gosec library.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|          | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran the action in csi-powerstore. https://github.com/dell/csi-powerstore/actions/runs/4051781148/jobs/6970456749
