### PR TITLE
Add option to run without the race detector

### DIFF
--- a/go-code-formatter-linter-vetter/Dockerfile
+++ b/go-code-formatter-linter-vetter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 LABEL "com.github.actions.name"="go-code-formatter-linter-vetter"
 LABEL "com.github.actions.description"="Checks for formatting, linting, and vetting issues"

--- a/go-code-tester/Dockerfile
+++ b/go-code-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 LABEL "com.github.actions.name"="go-code-tester"
 LABEL "com.github.actions.description"="Runs unit tests and verifies code coverage per package"

--- a/go-code-tester/README.md
+++ b/go-code-tester/README.md
@@ -28,6 +28,8 @@ jobs:
           test-folder: "."
           # Optional parameter to skip certain packages
           skip-list: "this/pkg1,this/pkg2"
+          # Optional paramter to enable the race detector
+          race-detector: "true"
 ```
 
 The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
@@ -35,3 +37,5 @@ The `threshold` for the Action is a coverage percentage threshold that every pac
 The `test-folder` is for specifying what folder to run the test command in. The default value is the current folder, `"."`
 
 The `skip-list` is an optional parameter. It should be a comma delimited string of package names to skip for the testing coverage criteria.
+
+The `race-detector` is an optional boolean parameter to enable or disable the race detector. 

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2020-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ runs:
     - ${{ inputs.threshold }}
     - ${{ inputs.test-folder }}
     - ${{ inputs.skip-list }}
+    - ${{ inputs.race-detector }}
 branding:
   icon: 'shield'
   color: 'blue'

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -11,7 +11,7 @@ inputs:
   threshold:
     description: 'Code coverage threshold for packages'
     required: true
-    default: 90
+    default: "90"
   test-folder:
     description: 'Folder the test is run in'
     required: false
@@ -20,6 +20,10 @@ inputs:
     description: 'A comma delimited list of pkg names to skip for coverage constraint'
     required: false
     default: ""
+  race-detector:
+    description: 'Boolean to indicate running tests with the race detector'
+    required: false
+    default: "true"
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: ""
   race-detector:
-    description: 'Boolean to indicate running tests with the race detector'
+    description: 'Boolean to enable the race detector'
     required: false
     default: "true"
 runs:

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2020-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ pkg_skip_list=
 go clean -testcache
 
 cd ${TEST_FOLDER}
-if [ -z "$RACE_DETECTOR" || "$RACE_DETECTOR" -eq "true" ]; then
+if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
   go test -v -short -race -count=1 -cover ./... > ~/run.log
 else
   # Run without the race flag

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -11,12 +11,19 @@
 THRESHOLD=$1
 TEST_FOLDER=$2
 SKIP_LIST=$3
+RACE_DETECTOR=$4
 pkg_skip_list=
 
 go clean -testcache
 
 cd ${TEST_FOLDER}
-go test -v -short -race -count=1 -cover ./... > ~/run.log
+if [ -z "$RACE_DETECTOR" || "$RACE_DETECTOR" -eq "true" ]; then
+  go test -v -short -race -count=1 -cover ./... > ~/run.log
+else
+  # Run without the race flag
+  go test -v -short -count=1 -cover ./... > ~/run.log
+fi
+
 TEST_RETURN_CODE=$?
 cat ~/run.log
 if [ "${TEST_RETURN_CODE}" != "0" ]; then

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -61,13 +61,13 @@ if [ -z "$SKIP_LIST" ]; then
   while read pkg cov;
   do
     check_coverage $pkg $cov
-  done <<< $(cat ~/run.log | grep -e "\scoverage" | awk '{print $2, substr($5, 1, length($5)-1)}')
+  done <<< $(cat ~/run.log | grep ^ok | awk '{print $2, substr($5, 1, length($5)-1)}')
 else
   # this is the same as the above, except it includes a filter that gets rid of all the packages that appear in the skip-list
   while read pkg cov;
   do
     check_coverage $pkg $cov
-  done <<< $(cat ~/run.log | grep -e "\scoverage" | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}')
+  done <<< $(cat ~/run.log | grep ^ok | grep -vw -e $SKIP_LIST_FOR_GREP | awk '{print $2, substr($5, 1, length($5)-1)}')
 fi
 
 exit ${FAIL}

--- a/gosec-runner/Dockerfile
+++ b/gosec-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18
+FROM golang:1.20
 
 LABEL "com.github.actions.name"="gosec-runner"
 LABEL "com.github.actions.description"="Runs gosec"


### PR DESCRIPTION
# Description
- Adds an optional parameter to run the go-code-tester without the go race detector
- Updates go to 1.20 and fixes an issue with grep to get the correct package and coverage

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|   https://github.com/dell/csm/issues/733     | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested changes in Resiliency PR https://github.com/dell/karavi-resiliency/actions/runs/4485153110/jobs/7886411579?pr=156
