### PR TITLE
Update go test check for Go 1.22

### DIFF
--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -18,10 +18,10 @@ go clean -testcache
 
 cd ${TEST_FOLDER}
 if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
-  go test -v -short -race -count=1 -cover ./... > ~/run.log
+  GOEXPERIMENT=nocoverageredesign go test -v -short -race -count=1 -cover ./... > ~/run.log
 else
   # Run without the race flag
-  go test -v -short -count=1 -cover ./... > ~/run.log
+  GOEXPERIMENT=nocoverageredesign go test -v -short -count=1 -cover ./... > ~/run.log
 fi
 
 TEST_RETURN_CODE=$?


### PR DESCRIPTION
# Description
There is a change in Go 1.22 with how code coverage is generated. In earlier versions, packages without any tests wouldn't be included in the overall coverage but now packages without tests are accounted for in the overall coverage. Adding `GOEXPERIMENT=nocoverageredesign` will give us the expected coverage in Go 1.22. We will have to revisit this if this variable is removed in Go 1.23.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|          | 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
