### PR TITLE
Add option to support the -skip argument to go test

### DIFF
--- a/go-code-tester/README.md
+++ b/go-code-tester/README.md
@@ -30,6 +30,9 @@ jobs:
           skip-list: "this/pkg1,this/pkg2"
           # Optional paramter to enable the race detector
           race-detector: "true"
+          # Optional  parameter to skip tests
+          skip-test: "TestToSkip"
+
 ```
 
 The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
@@ -38,4 +41,6 @@ The `test-folder` is for specifying what folder to run the test command in. The 
 
 The `skip-list` is an optional parameter. It should be a comma delimited string of package names to skip for the testing coverage criteria.
 
-The `race-detector` is an optional boolean parameter to enable or disable the race detector. 
+The `race-detector` is an optional boolean parameter to enable or disable the race detector.
+
+The `skip-test` is a regex and passed directly as the -skip option to the `go test` command.

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2020-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,6 +24,10 @@ inputs:
     description: 'Boolean to enable the race detector'
     required: false
     default: "true"
+  skip-test:
+    description: 'Regex for sipping tests'
+    required: false
+    default: ""
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -32,6 +36,7 @@ runs:
     - ${{ inputs.test-folder }}
     - ${{ inputs.skip-list }}
     - ${{ inputs.race-detector }}
+    - ${{ inputs.skip-test }}
 branding:
   icon: 'shield'
   color: 'blue'

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
     default: "true"
   skip-test:
-    description: 'Regex for sipping tests'
+    description: 'Regex for skipping tests'
     required: false
     default: ""
 runs:

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -17,10 +17,10 @@ SKIP_TEST=$5
 skip_options=""
 
 if [[ -z $SKIP_TEST ]]; then
-  echo "No packages in skip-test"
+  echo "running all tests in packages"
 else
   echo "skipping the following tests (regex): $SKIP_TEST"
-  skip_options="-skip \"$SKIP_TEST\""
+  skip_options="-skip $SKIP_TEST"
 fi
 
 go clean -testcache

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020-2023 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2020-2024 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,25 @@ THRESHOLD=$1
 TEST_FOLDER=$2
 SKIP_LIST=$3
 RACE_DETECTOR=$4
-pkg_skip_list=
+SKIP_TEST=$5
+
+skip_options=""
+
+if [[ -z $SKIP_TEST ]]; then
+  echo "No packages in skip-test"
+else
+  echo "skipping the following tests (regex): $SKIP_TEST"
+  skip_options="-skip \'$SKIP_TEST\'"
+fi
 
 go clean -testcache
 
 cd ${TEST_FOLDER}
 if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
-  GOEXPERIMENT=nocoverageredesign go test -v -short -race -count=1 -cover ./... > ~/run.log
+  GOEXPERIMENT=nocoverageredesign go test $skip_options -v -short -race -count=1 -cover ./... > ~/run.log
 else
   # Run without the race flag
-  GOEXPERIMENT=nocoverageredesign go test -v -short -count=1 -cover ./... > ~/run.log
+  GOEXPERIMENT=nocoverageredesign go test $skip_options -v -short -count=1 -cover ./... > ~/run.log
 fi
 
 TEST_RETURN_CODE=$?

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -20,7 +20,7 @@ if [[ -z $SKIP_TEST ]]; then
   echo "No packages in skip-test"
 else
   echo "skipping the following tests (regex): $SKIP_TEST"
-  skip_options="-skip \'$SKIP_TEST\'"
+  skip_options="-skip \"$SKIP_TEST\""
 fi
 
 go clean -testcache


### PR DESCRIPTION
# Description
Added a new field, skip-test which is passed to the -skip option of go test. This is useful for repositories that have a mix of unit tests and tests that require an array. It's more difficult to separate those tests so starting to enable more unit testing by allowing for the ability to skip those tests, which are normally BDD tests using godog.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|[1422](https://github.com/dell/csm/issues/1422) |

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Tested using act to run action from a csi driver repo which uses the new option and validated that the specified test was skipped.
- [X] Tested without the new field to validate that existing actions do not break.
