### PR TITLE
Disable yamllint errors for braces and brackets

### DIFF
--- a/.github/configs/yamllint/yamllint.yaml
+++ b/.github/configs/yamllint/yamllint.yaml
@@ -13,8 +13,8 @@ yaml-files:
   - ".yamllint"
 
 rules:
-  braces: enable
-  brackets: enable
+  braces: disable
+  brackets: disable
   colons: enable
   commas: enable
   comments:


### PR DESCRIPTION
With templated yaml, like is found in helm charts, the spacing is required.

# Description
Disabling errors regarding extra spaces within braces and brackets


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works


