### PR TITLE
Add go run option to run specific tests

### DIFF
--- a/go-code-tester/README.md
+++ b/go-code-tester/README.md
@@ -34,7 +34,7 @@ jobs:
           # Optional parameter to skip tests
           skip-test: "TestToSkip"
           # Optional parameter to specify regex for tests to run
-          run-list: "TestToRun"
+          run-test: "TestToRun"
 ```
 
 The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
@@ -47,4 +47,4 @@ The `race-detector` is an optional boolean parameter to enable or disable the ra
 
 The `skip-test` is a regex and passed directly as the -skip option to the `go test` command.
 
-The `run-list` is a regex and passed directly as the -run option to the `go test` command.
+The `run-test` is a regex and passed directly as the -run option to the `go test` command.

--- a/go-code-tester/README.md
+++ b/go-code-tester/README.md
@@ -31,9 +31,10 @@ jobs:
           skip-list: "this/pkg1,this/pkg2"
           # Optional paramter to enable the race detector
           race-detector: "true"
-          # Optional  parameter to skip tests
+          # Optional parameter to skip tests
           skip-test: "TestToSkip"
-
+          # Optional parameter to specify regex for tests to run
+          run-list: "TestToRun"
 ```
 
 The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
@@ -45,3 +46,5 @@ The `skip-list` is an optional parameter. It should be a comma delimited string 
 The `race-detector` is an optional boolean parameter to enable or disable the race detector.
 
 The `skip-test` is a regex and passed directly as the -skip option to the `go test` command.
+
+The `run-list` is a regex and passed directly as the -run option to the `go test` command.

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -37,6 +37,7 @@ runs:
     - ${{ inputs.skip-list }}
     - ${{ inputs.race-detector }}
     - ${{ inputs.skip-test }}
+    - ${{ inputs.run-test }}
 branding:
   icon: 'shield'
   color: 'blue'

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -13,24 +13,29 @@ TEST_FOLDER=$2
 SKIP_LIST=$3
 RACE_DETECTOR=$4
 SKIP_TEST=$5
+RUN_TEST=$6
 
 skip_options=""
+run_options=""
 
-if [[ -z $SKIP_TEST ]]; then
-  echo "running all tests in packages"
-else
+if [[ -n $SKIP_TEST ]]; then
   echo "skipping the following tests (regex): $SKIP_TEST"
   skip_options="-skip $SKIP_TEST"
+fi
+
+if [[ -n $RUN_TEST ]]; then
+  echo "running the following tests (regex): $RUN_TEST"
+  run_options="-run $RUN_TEST"
 fi
 
 go clean -testcache
 
 cd ${TEST_FOLDER}
 if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
-  GOEXPERIMENT=nocoverageredesign go test $skip_options -v -short -race -count=1 -cover ./... > ~/run.log
+  GOEXPERIMENT=nocoverageredesign go test $skip_options -v -short -race -count=1 -cover $run_options ./... > ~/run.log
 else
   # Run without the race flag
-  GOEXPERIMENT=nocoverageredesign go test $skip_options -v -short -count=1 -cover ./... > ~/run.log
+  GOEXPERIMENT=nocoverageredesign go test $skip_options -v -short -count=1 -cover $run_options ./... > ~/run.log
 fi
 
 TEST_RETURN_CODE=$?
@@ -80,4 +85,3 @@ else
 fi
 
 exit ${FAIL}
-


### PR DESCRIPTION
# Description
Add the -run option to the go test command as some repos have mixed unit and integration tests. In some repos it is useful to skip some tests while in other repos it is useful to run some tests. I have made the action more flexible.

# Issues
List the issues impacted by this PR:

The action is required to support running unit tests for gonvme which is part of another PR.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Tested action with run-test option and validated that the test specified was run.
- [X] Tested action with skip-test option and validated that the test specified was skipped.
