### PR TITLE
Consolidate common workflows

### DIFF
--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -38,3 +38,13 @@ jobs:
 
       - name: gosec
         uses: dell/common-github-actions/gosec-runner@main
+
+  formatter_vetter:
+    name: Go Formatter and Vetter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: gofmt and go vet
+        uses: dell/common-github-actions/go-code-formatter-vetter@main

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -6,7 +6,7 @@
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
 
-# Reusable workflow to run unit tests and gosec on Golang based projects
+# Reusable workflow to run multiple workflow checks on Golang based projects
 name: Common Workflows
 
 on:

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ jobs:
 
 ### go-common
 
-This workflow runs unit tests, checks package coverage and runs gosec against repositories that utilize Golang as the primary development language.
+This workflow runs multiple checks against repositories that utilize Golang as the primary development language. Currently, this workflow will run unit tests, check package coverage, gosec, and go formatter and vetter.
 
 ```
 name: Common Workflows
@@ -136,9 +136,8 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
 
-  # unit tester and gosec runner
   common:
-    name: Run gosec, unit tests, and check package coverage
+    name: Quality Checks
     uses: dell/common-github-actions/.github/workflows/go-common.yml@main
 ```
 

--- a/go-code-formatter-vetter/Dockerfile
+++ b/go-code-formatter-vetter/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.23
 
-LABEL "com.github.actions.name"="go-code-formatter-linter-vetter"
-LABEL "com.github.actions.description"="Checks for formatting, linting, and vetting issues"
+LABEL "com.github.actions.name"="go-code-formatter-vetter"
+LABEL "com.github.actions.description"="Checks for formatting and vetting issues"
 LABEL "com.github.actions.icon"="eye"
 LABEL "com.github.actions.color"="gray-dark"
 

--- a/go-code-formatter-vetter/README.md
+++ b/go-code-formatter-vetter/README.md
@@ -1,6 +1,6 @@
-# Code Formatter-Linter-Vetter GitHub Action
+# Code Formatter-Vetter GitHub Action
 
-This GitHub Action can be used to check sources files for formatting, linting, and vetting issues.
+This GitHub Action can be used to check sources files for formatting and vetting issues.
 
 To enable this Action, you can create a .yml file under your repo's .github/workflows directory.
 Simple example:
@@ -17,13 +17,13 @@ on:
 jobs:
 
   code-check:
-    name: Check formatting, linting, vetting
+    name: Check formatting and vetting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
         uses: actions/checkout@v4
-      - name: Run the formatter, linter, and vetter
-        uses: dell/common-github-actions/go-code-formatter-linter-vetter@main
+      - name: Run the formatter and vetter
+        uses: dell/common-github-actions/go-code-formatter-vetter@main
         with:
           directories: ./...
 ```

--- a/go-code-formatter-vetter/action.yml
+++ b/go-code-formatter-vetter/action.yml
@@ -5,8 +5,8 @@
 # You may obtain a copy of the License at
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
-name: 'Check Formatting, Linting, Vetting'
-description: 'Runs gofmt, golint, and go vet'
+name: 'Check Formatting, Vetting'
+description: 'Runs gofmt and go vet'
 
 inputs:
   directories:

--- a/go-code-formatter-vetter/entrypoint.sh
+++ b/go-code-formatter-vetter/entrypoint.sh
@@ -84,17 +84,9 @@ if [ $VET_IN_DIR -eq 1 ]; then
    cd - || exit 1
 fi
 
-echo === Linting...
-(command -v golint >/dev/null 2>&1 \
-    || go install golang.org/x/lint/golint@latest) \
-    && golint --set_exit_status ${CHECK_DIRS}
-LINT_RETURN_CODE=$?
-echo === Finished
-
 # Report output.
 fail_checks=0
 [ "${FMT_RETURN_CODE}" != "0" ] && echo "Formatting checks failed! => Run 'make format'." && fail_checks=1
 [ "${VET_RETURN_CODE}" != "0" ] && echo "Vetting checks failed!" && fail_checks=1
-[ "${LINT_RETURN_CODE}" != "0" ] && echo "Linting checks failed!" && fail_checks=1
 
 exit ${fail_checks}


### PR DESCRIPTION
# Description
Remove linter from go-code-formatter-linter-vetter check in favor of using golangci-lint in `.github/workflows/go-static-analysis.yaml`. 
Adds formatter and linter to common workflows.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|    https://github.com/dell/csm/issues/1490      | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
