### PR TITLE
Add option to exclude directories from go test

### DIFF
--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -21,6 +21,7 @@ env:
   RACE_DETECTOR: ${{ vars.RACE_DETECTOR || true }}
   SKIP_TEST: ${{ vars.SKIP_TEST || '' }}
   RUN_TEST: ${{ vars.RUN_TEST || '' }}
+  EXCLUDE_DIRECTORIES: ${{ vars.EXCLUDE_DIRECTORIES || '' }}
 
   # gosec action
   GOSEC_EXCLUDES: ${{ vars.GOSEC_EXCLUDES || '' }}
@@ -44,6 +45,7 @@ jobs:
           race-detector: ${{ env.RACE_DETECTOR }}
           skip-test: ${{ env.SKIP_TEST }}
           run-test: ${{ env.RUN_TEST }}
+          exclude-directory: ${{ env.EXCLUDE_DIRECTORIES }}
 
   # Check sources for security vulnerabilities
   security:

--- a/go-code-tester/README.md
+++ b/go-code-tester/README.md
@@ -35,6 +35,8 @@ jobs:
           skip-test: "TestToSkip"
           # Optional parameter to specify regex for tests to run
           run-test: "TestToRun"
+          # Optional paramter to exlude certain directories from go test. Ex. intregration test folders.
+          exclude-directory: "DirectoryToExclude|DirectoryToExclude2"
 ```
 
 The `threshold` for the Action is a coverage percentage threshold that every package must meet. The default `threshold` is 90.
@@ -48,3 +50,5 @@ The `race-detector` is an optional boolean parameter to enable or disable the ra
 The `skip-test` is a regex and passed directly as the -skip option to the `go test` command.
 
 The `run-test` is a regex and passed directly as the -run option to the `go test` command.
+
+The `exclude-directory` is an optional parameter to filter out directories you want to exclude from the `go test` command.

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Regex to specify tests to run'
     required: false
     default: ""
+  exclude-directory:
+    description: 'Name of directory to be excluded from go test'
+    required: false
+    default: ""
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -42,6 +46,7 @@ runs:
     - ${{ inputs.race-detector }}
     - ${{ inputs.skip-test }}
     - ${{ inputs.run-test }}
+    - ${{ inputs.exclude-directory }}
 branding:
   icon: 'shield'
   color: 'blue'

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -14,6 +14,7 @@ SKIP_LIST=$3
 RACE_DETECTOR=$4
 SKIP_TEST=$5
 RUN_TEST=$6
+EXCLUDE_DIRECTORIES=$7
 
 skip_options=""
 run_options=""
@@ -31,10 +32,15 @@ fi
 go clean -testcache
 
 cd ${TEST_FOLDER}
-if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
-  GOEXPERIMENT=nocoverageredesign go test $skip_options -v -short -race -count=1 -cover $run_options ./... > ~/run.log
+if [[ -n $EXCLUDE_DIRECTORIES ]]; then
+  echo "excluding the following directories: $EXCLUDE_DIRECTORIES"
+  if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
+    GOEXPERIMENT=nocoverageredesign go test $skip_options -v $(go list ./... | grep -vE $EXCLUDE_DIRECTORIES) -short -race -count=1 -cover $run_options ./... > ~/run.log
+  else
+    # Run without the race flag
+    GOEXPERIMENT=nocoverageredesign go test $skip_options -v $(go list ./... | grep -vE $EXCLUDE_DIRECTORIES) -short -count=1 -cover $run_options ./... > ~/run.log
+  fi
 else
-  # Run without the race flag
   GOEXPERIMENT=nocoverageredesign go test $skip_options -v -short -count=1 -cover $run_options ./... > ~/run.log
 fi
 


### PR DESCRIPTION
# Description
PR will allow us to exclude directories from unit test check. Some repos, like goscaleio have integration testing in a directory and unit tests in the root directory. The goal is to only run UT as part of PR builds.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|  https://github.com/dell/csm/issues/1490        | 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Tested in forked repo: https://github.com/shaynafinocchiaro/test-goscaleio/actions/runs/11839540582/job/32991217055
