### PR TITLE
Add Trigger Spell Check and Autofix Workflow for CSM-DOCs

### DIFF
--- a/.github/workflows/trigger-spellcheck-autofix.yaml
+++ b/.github/workflows/trigger-spellcheck-autofix.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Trigger workflow for go version update on CSM projects
+name: Trigger Spell Check and Autofix Workflow in CSM-DOCs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    name: Trigger Spell Check and Autofix Job
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        repo:
+          [
+            "dell/csm-docs",
+          ]
+
+    steps:
+      - name: Dispatch Spell Check Event to CSM-DOCs Repository
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          # For token information, see: https://github.com/peter-evans/repository-dispatch/tree/main?tab=readme-ov-file#token
+          token: ${{ secrets.CSMBOT_PAT }}
+          repository: ${{ matrix.repo }}
+          event-type: trigger-spell-check-autofix
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
# Description
This pull request introduces a new GitHub Actions workflow designed to trigger the spell check and autofix process in the CSM-DOCs repository. This workflow facilitates the automatic invocation of spell check and correction workflows in targeted repositories, ensuring that documentation remains clean, consistent, and free from common spelling errors.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/csm/issues/1490 | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested in Forked workflows https://github.com/mgandharva/test-csm-docs/actions, https://github.com/mgandharva/test-common-github-actions/actions
