### PR TITLE
Add back skip list functionality

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,8 @@ updates:
       interval: "daily"
       time: "18:00"
     allow:
-      # Allow both direct and indirect updates for all packages
-      - dependency-type: all
+      # Allow direct updates for packages
+      - dependency-type: direct
     # a group of dependencies will be updated together in one pull request
     groups:
       golang:
@@ -22,7 +22,6 @@ updates:
         update-types:
           - major
           - minor
-          - patch
         patterns:
           - "*"
 

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run unit tests and check package coverage
         id: test_coverage
-        uses: dell/common-github-actions/go-code-tester@fix-ut-action
+        uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: ${{ env.CODE_COVERAGE_TARGET }}
           test-folder: ${{ env.CODE_COVERAGE_DIR }}

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run unit tests and check package coverage
         id: test_coverage
-        uses: dell/common-github-actions/go-code-tester@main
+        uses: dell/common-github-actions/go-code-tester@fix-ut-action
         with:
           threshold: ${{ env.CODE_COVERAGE_TARGET }}
           test-folder: ${{ env.CODE_COVERAGE_DIR }}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -21,6 +21,16 @@ run_options=""
 
 declare -A coverage_results
 
+# Skip packages in the skip list
+if [ -z "$SKIP_LIST" ]; then
+  echo "No packages in skip-list"
+else
+  # Put skip list in grep-friendly and human-friendly formats
+  SKIP_LIST_FOR_GREP=${SKIP_LIST//[,]/ -e }
+  SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
+  echo "Skipping the following packages: $SKIP_LIST_FOR_ECHO"
+fi
+
 if [[ -n $SKIP_TEST ]]; then
   echo "skipping the following tests (regex): $SKIP_TEST"
   skip_options="-skip $SKIP_TEST"
@@ -86,22 +96,6 @@ for submodule in $submodules; do
   fi
 
   for package in $packages; do
-    # Skip packages in the skip list
-    if [ -z "$SKIP_LIST" ]; then
-      echo "No packages in skip-list"
-    else
-      # Put skip list in grep-friendly and human-friendly formats
-      SKIP_LIST_FOR_GREP=${SKIP_LIST//[,]/ -e }
-      SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
-      echo "Skipping the following packages: $SKIP_LIST_FOR_ECHO"
-    fi
-
-    # Check if the package is in the skip list
-    if echo "$package" | grep -q -e "$SKIP_LIST_FOR_GREP"; then
-      echo "Skipping package $package"
-      continue
-    fi
-
     # Run go test with coverage for the package
     if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
       # Run with the race flag
@@ -133,6 +127,13 @@ for submodule in $submodules; do
 
   cd - > /dev/null
 done
+
+# Remove skipped packages from coverage_results, but the unit tests will still run
+if [ -n "$SKIP_LIST" ]; then
+  for pkg in ${SKIP_LIST//,/ }; do
+    unset coverage_results["$pkg"]
+  done
+fi
 
 # Check if coverage meets the minimum threshold
 echo "Coverage results:"

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -87,13 +87,19 @@ for submodule in $submodules; do
 
   for package in $packages; do
     # Skip packages in the skip list
-    if [[ -n "$SKIP_LIST" ]]; then
-      for skip in $SKIP_LIST; do
-        if [[ $skip == $package ]]; then
-          echo "Skipping package $package"
-          continue 2
-        fi
-      done
+    if [ -z "$SKIP_LIST" ]; then
+      echo "No packages in skip-list"
+    else
+      # Put skip list in grep-friendly and human-friendly formats
+      SKIP_LIST_FOR_GREP=${SKIP_LIST//[,]/ -e }
+      SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
+      echo "Skipping the following packages: $SKIP_LIST_FOR_ECHO"
+    fi
+
+    # Check if the package is in the skip list
+    if echo "$package" | grep -q -e "$SKIP_LIST_FOR_GREP"; then
+      echo "Skipping package $package"
+      continue
     fi
 
     # Run go test with coverage for the package

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -138,11 +138,12 @@ fi
 
 # Report failed packages
 if [ ${#failed_packages[@]} -ne 0 ]; then
-  echo -e "\nThe following packages failed tests and were not checked for coverage:"
+  echo ""
+  echo "The following packages failed tests and were not checked for coverage:"
   for pkg in "${failed_packages[@]}"; do
     echo "$pkg"
   done
-  echo -e "\n"
+  echo ""
 fi
 
 # Check if coverage meets the minimum threshold

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -138,10 +138,11 @@ fi
 
 # Report failed packages
 if [ ${#failed_packages[@]} -ne 0 ]; then
-  echo "The following packages failed tests and were not checked for coverage:"
+  echo -e "\nThe following packages failed tests and were not checked for coverage:"
   for pkg in "${failed_packages[@]}"; do
     echo "$pkg"
   done
+  echo -e "\n"
 fi
 
 # Check if coverage meets the minimum threshold

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -98,15 +98,15 @@ for submodule in $submodules; do
     # Run go test with coverage for the package
     if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
       # Run with the race flag
-      output=$(go test $skip_options -v -short -race -count=1 -cover $package $run_options 2>&1)
+      output=$(go test $skip_options -v -short -race -count=1 -cover $package $run_options)
       TEST_RETURN_CODE=$?
     else
       # Run without the race flag
-      output=$(go test $skip_options -v -short -count=1 -cover $package $run_options 2>&1)
+      output=$(go test $skip_options -v -short -count=1 -cover $package $run_options)
       TEST_RETURN_CODE=$?
     fi
 
-    echo "$output"
+    # echo "$output"
 
     if [ "${TEST_RETURN_CODE}" != "0" ]; then
       echo "test failed for package $package with return code $TEST_RETURN_CODE, not proceeding with coverage check"

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -20,6 +20,7 @@ skip_options=""
 run_options=""
 
 declare -A coverage_results
+declare -a failed_packages
 
 # Skip packages in the skip list
 if [ -z "$SKIP_LIST" ]; then

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -98,11 +98,11 @@ for submodule in $submodules; do
     # Run go test with coverage for the package
     if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
       # Run with the race flag
-      output=$(go test $skip_options -v -short -race -count=1 -cover $package $run_options)
+      output=$(go test $skip_options -v -short -race -count=1 -cover $package $run_options 2>&1)
       TEST_RETURN_CODE=$?
     else
       # Run without the race flag
-      output=$(go test $skip_options -v -short -count=1 -cover $package $run_options)
+      output=$(go test $skip_options -v -short -count=1 -cover $package $run_options 2>&1)
       TEST_RETURN_CODE=$?
     fi
 
@@ -110,6 +110,7 @@ for submodule in $submodules; do
 
     if [ "${TEST_RETURN_CODE}" != "0" ]; then
       echo "test failed for package $package with return code $TEST_RETURN_CODE, not proceeding with coverage check"
+      failed_packages+=("$package")
       FAIL=1
     fi
 
@@ -131,6 +132,14 @@ done
 if [ -n "$SKIP_LIST" ]; then
   for pkg in ${SKIP_LIST//,/ }; do
     unset coverage_results["$pkg"]
+  done
+fi
+
+# Report failed packages
+if [ ${#failed_packages[@]} -ne 0 ]; then
+  echo "The following packages failed tests and were not checked for coverage:"
+  for pkg in "${failed_packages[@]}"; do
+    echo "$pkg"
   done
 fi
 

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -87,9 +87,13 @@ for submodule in $submodules; do
 
   for package in $packages; do
     # Skip packages in the skip list
-    if [[ -n "$SKIP_LIST" && $SKIP_LIST =~ $package ]]; then
-      echo "Skipping package $package"
-      continue
+    if [[ -n "$SKIP_LIST" ]]; then
+      for skip in $SKIP_LIST; do
+        if [[ $skip == $package ]]; then
+          echo "Skipping package $package"
+          continue 2
+        fi
+      done
     fi
 
     # Run go test with coverage for the package

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -106,7 +106,7 @@ for submodule in $submodules; do
       TEST_RETURN_CODE=$?
     fi
 
-    # echo "$output"
+    echo "$output"
 
     if [ "${TEST_RETURN_CODE}" != "0" ]; then
       echo "test failed for package $package with return code $TEST_RETURN_CODE, not proceeding with coverage check"

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -25,8 +25,7 @@ declare -A coverage_results
 if [ -z "$SKIP_LIST" ]; then
   echo "No packages in skip-list"
 else
-  # Put skip list in grep-friendly and human-friendly formats
-  SKIP_LIST_FOR_GREP=${SKIP_LIST//[,]/ -e }
+  # Put skip list in human-friendly formats
   SKIP_LIST_FOR_ECHO=${SKIP_LIST//[,]/, }
   echo "Skipping the following packages: $SKIP_LIST_FOR_ECHO"
 fi


### PR DESCRIPTION
# Description
Skip_list functionality was removed in an earlier PR #113. 
This PR removes the skipped packages from coverage_results array so the threshold is not reported at them, but we will still run go test for those packages.
For any failed packages, we will print that list at the end of the run so its not lost in test output


# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/csm/issues/1733         | 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested skip list https://github.com/shaynafinocchiaro/test-karavi-authorization/actions/runs/13116106041/job/36601156125?pr=1
