### PR TITLE
Add UT coverage tool & Trigger Job for golibs

### DIFF
--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Coverage results
         run: |
           echo -e "Coverage results: ${{ steps.test_coverage.outputs.coverage }}"
+          echo -e "Report: ${{ steps.test_coverage.outputs.code_coverage_artifact }}"
 
       # Used as an indicator of the quality of changes introduced for a package
       # by showing if package coverage has increased or decreased

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -71,7 +71,7 @@ jobs:
           path: ${{ steps.test_coverage.outputs.code_coverage_artifact }}
 
       # Used as an indicator of the quality of changes introduced for a package
-      # by showing if package coverage has increased or decreased
+      # by showing if package coverage has increased, decreased, or stayed the same
       - name: Generate coverage report
         # we don't want this check to run on merging to main because it will reset coverage.txt to an empty artifact
         if: ${{ !cancelled() }} && github.event.name == 'pull_request'

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -73,7 +73,8 @@ jobs:
           path: coverage.txt
 
       - name: Code coverage report
-        if: ${{ !cancelled() }}
+        # we don't want this check to run on merging to main because it will reset coverage.txt to an empty artifact
+        if: ${{ !cancelled() }} && github.event.name == 'pull_request'
         # code coverage profiles are uploaded as GitHub artifacts, which automatically expire after 90 days
         # if no coverage profile exists on main branch yet, then the step will fail
         continue-on-error: true

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
 
@@ -62,19 +62,18 @@ jobs:
       - name: Coverage results
         run: |
           echo -e "Coverage results: ${{ steps.test_coverage.outputs.coverage }}"
-          echo -e "Report: ${{ steps.test_coverage.outputs.code_coverage_artifact }}"
 
       # Used as an indicator of the quality of changes introduced for a package
       # by showing if package coverage has increased or decreased
       - name: Archive code coverage results
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage
-          path: ${{ steps.test_coverage.outputs.code_coverage_artifact }}
+          path: coverage.txt
 
       - name: Code coverage report
-        if: always()
+        if: ${{ !cancelled() }}
         uses: fgrosse/go-coverage-report@v1.2.0
         with:
           coverage-artifact-name: "code-coverage"

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -65,8 +65,8 @@ jobs:
 
       # Used as an indicator of the quality of changes introduced for a package
       # by showing if package coverage has increased or decreased
-      - name: Archive code coverage results
-        if: ${{ !cancelled() }}
+      - name: Upload coverage report
+        if: ${{ !cancelled() }} && github.event.name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -32,9 +32,20 @@ jobs:
   gocoverage:
     name: Unit tests and package coverage
     runs-on: ubuntu-latest
+    # Needed for "fgrosse/go-coverage-report"
+    permissions:
+      contents: read
+      actions: read  # to download code coverage results from "Test" job
+      pull-requests: write # write permission needed to comment on PR
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23"
 
       - name: Run unit tests and check package coverage
         id: test_coverage
@@ -52,32 +63,13 @@ jobs:
         run: |
           echo -e "Coverage results: ${{ steps.test_coverage.outputs.coverage }}"
 
-  # Used as an indicator of the quality of changes introduced for a package
-  # by showing if package coverage has increased or decreased
-  coveragereport:
-    name: Create coverage report
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read  # to download code coverage results from "Test" job
-      pull-requests: write # write permission needed to comment on PR
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.23"
-
-      - name: Test
-        run: go test -cover -coverprofile=coverage.txt ./...
-
+      # Used as an indicator of the quality of changes introduced for a package
+      # by showing if package coverage has increased or decreased
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage
-          path: coverage.txt
+          path: ${{ steps.test_coverage.outputs.code_coverage_artifact }}
 
       - name: Code coverage report
         uses: fgrosse/go-coverage-report@v1.2.0

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -74,6 +74,9 @@ jobs:
 
       - name: Code coverage report
         if: ${{ !cancelled() }}
+        # code coverage profiles are uploaded as GitHub artifacts which automatically expire after 90 days
+        # if no coverage profile exists, the step will fail
+        continue-on-error: true
         uses: fgrosse/go-coverage-report@v1.2.0
         with:
           coverage-artifact-name: "code-coverage"

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           echo -e "Coverage results: ${{ steps.test_coverage.outputs.coverage }}"
 
-      - name: Upload coverage report
+      - name: Upload coverprofile
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
@@ -81,7 +81,7 @@ jobs:
         uses: fgrosse/go-coverage-report@v1.2.0
         with:
           coverage-artifact-name: "code-coverage"
-          coverage-file-name: "coverage.txt"
+          coverage-file-name: "new_coverage.txt"
 
   # Check sources for security vulnerabilities
   security:

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -66,12 +66,14 @@ jobs:
       # Used as an indicator of the quality of changes introduced for a package
       # by showing if package coverage has increased or decreased
       - name: Archive code coverage results
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage
           path: ${{ steps.test_coverage.outputs.code_coverage_artifact }}
 
       - name: Code coverage report
+        continue-on-error: true
         uses: fgrosse/go-coverage-report@v1.2.0
         with:
           coverage-artifact-name: "code-coverage"

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - name: Run unit tests and check package coverage
         id: test_coverage

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -74,8 +74,8 @@ jobs:
 
       - name: Code coverage report
         if: ${{ !cancelled() }}
-        # code coverage profiles are uploaded as GitHub artifacts which automatically expire after 90 days
-        # if no coverage profile exists, the step will fail
+        # code coverage profiles are uploaded as GitHub artifacts, which automatically expire after 90 days
+        # if no coverage profile exists on main branch yet, then the step will fail
         continue-on-error: true
         uses: fgrosse/go-coverage-report@v1.2.0
         with:

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run unit tests and check package coverage
         id: test_coverage
-        uses: dell/common-github-actions/go-code-tester@main
+        uses: dell/common-github-actions/go-code-tester@add-coverage-tool
         with:
           threshold: ${{ env.CODE_COVERAGE_TARGET }}
           test-folder: ${{ env.CODE_COVERAGE_DIR }}

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -35,7 +35,7 @@ jobs:
     # Needed for "fgrosse/go-coverage-report"
     permissions:
       contents: read
-      actions: read  # to download code coverage results from "Test" job
+      actions: read  # to download code coverage results from "Run unit tests and check package coverage" job
       pull-requests: write # write permission needed to comment on PR
 
     steps:

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -52,6 +52,39 @@ jobs:
         run: |
           echo -e "Coverage results: ${{ steps.test_coverage.outputs.coverage }}"
 
+  # Used as an indicator of the quality of changes introduced for a package
+  # by showing if package coverage has increased or decreased
+  coveragereport:
+    name: Create coverage report
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read  # to download code coverage results from "Test" job
+      pull-requests: write # write permission needed to comment on PR
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.23"
+
+      - name: Test
+        run: go test -cover -coverprofile=coverage.txt ./...
+
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage
+          path: coverage.txt
+
+      - name: Code coverage report
+        uses: fgrosse/go-coverage-report@v1.2.0
+        with:
+          coverage-artifact-name: "code-coverage"
+          coverage-file-name: "coverage.txt"
+
   # Check sources for security vulnerabilities
   security:
     name: GoSec

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run unit tests and check package coverage
         id: test_coverage
-        uses: dell/common-github-actions/go-code-tester@add-coverage-tool
+        uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: ${{ env.CODE_COVERAGE_TARGET }}
           test-folder: ${{ env.CODE_COVERAGE_DIR }}

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -63,16 +63,16 @@ jobs:
         run: |
           echo -e "Coverage results: ${{ steps.test_coverage.outputs.coverage }}"
 
-      # Used as an indicator of the quality of changes introduced for a package
-      # by showing if package coverage has increased or decreased
       - name: Upload coverage report
-        if: ${{ !cancelled() }} && github.event.name == 'pull_request'
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage
-          path: coverage.txt
+          path: ${{ steps.test_coverage.outputs.code_coverage_artifact }}
 
-      - name: Code coverage report
+      # Used as an indicator of the quality of changes introduced for a package
+      # by showing if package coverage has increased or decreased
+      - name: Generate coverage report
         # we don't want this check to run on merging to main because it will reset coverage.txt to an empty artifact
         if: ${{ !cancelled() }} && github.event.name == 'pull_request'
         # code coverage profiles are uploaded as GitHub artifacts, which automatically expire after 90 days

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Code coverage report
         # we don't want this check to run on merging to main because it will reset coverage.txt to an empty artifact
-        if: ${{ !cancelled() }} && github.event.name == 'pull_request'
+        if: ${{ !cancelled() }} || github.event.name == 'pull_request'
         # code coverage profiles are uploaded as GitHub artifacts, which automatically expire after 90 days
         # if no coverage profile exists on main branch yet, then the step will fail
         continue-on-error: true

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Code coverage report
         # we don't want this check to run on merging to main because it will reset coverage.txt to an empty artifact
-        if: ${{ !cancelled() }} || github.event.name == 'pull_request'
+        if: ${{ !cancelled() }} && github.event.name == 'pull_request'
         # code coverage profiles are uploaded as GitHub artifacts, which automatically expire after 90 days
         # if no coverage profile exists on main branch yet, then the step will fail
         continue-on-error: true

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -66,14 +66,14 @@ jobs:
       # Used as an indicator of the quality of changes introduced for a package
       # by showing if package coverage has increased or decreased
       - name: Archive code coverage results
-        continue-on-error: true
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage
           path: ${{ steps.test_coverage.outputs.code_coverage_artifact }}
 
       - name: Code coverage report
-        continue-on-error: true
+        if: always()
         uses: fgrosse/go-coverage-report@v1.2.0
         with:
           coverage-artifact-name: "code-coverage"

--- a/.github/workflows/trigger-update-libraries-to-commits.yml
+++ b/.github/workflows/trigger-update-libraries-to-commits.yml
@@ -11,7 +11,7 @@ name: Trigger Update Dell Packages to Latest Commits
 
 on:
   schedule:
-    - cron: '0 12 * * 1' # Runs every Monday at midnight
+    - cron: '0 12 * * 0' # Runs every Sunday at midnight
   # Can be manually triggered
   workflow_dispatch:
 

--- a/.github/workflows/trigger-update-libraries-to-commits.yml
+++ b/.github/workflows/trigger-update-libraries-to-commits.yml
@@ -6,7 +6,7 @@
 #
 #  http://www.apache.org/licenses/LICENSE-2.0
 
-# Trigger workflow to update Dell packages to their latest released version
+# Trigger workflow to update Dell packages to their latest commits
 name: Trigger Update Dell Packages to Latest Commits
 
 on:

--- a/.github/workflows/trigger-update-libraries-to-commits.yml
+++ b/.github/workflows/trigger-update-libraries-to-commits.yml
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 Dell Inc., or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Trigger workflow to update Dell packages to their latest released version
+name: Trigger Update Dell Packages to Latest Commits
+
+on:
+  schedule:
+    - cron: '0 12 * * 1' # Runs every Monday at midnight
+  # Can be manually triggered
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    name: Trigger Dell Packages Update
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Note: dell-csi-extensions isn't included here because it's handled in its own release action
+        repo:
+          [
+            "dell/cert-csi",
+            "dell/cosi",
+            "dell/csi-metadata-retriever",
+            "dell/csi-powerflex",
+            "dell/csi-powermax",
+            "dell/csi-powerscale",
+            "dell/csi-powerstore",
+            "dell/csi-unity",
+            "dell/csm-metrics-powermax",
+            "dell/csm-metrics-powerscale",
+            "dell/csm-metrics-powerstore",
+            "dell/csm-metrics-unity",
+            "dell/csm-operator",
+            "dell/csm-replication",
+            "dell/gobrick",
+            "dell/karavi-authorization",
+            "dell/karavi-metrics-powerflex",
+            "dell/karavi-resiliency",
+            "dell/karavi-topology",
+          ]
+
+    steps:
+      - name: Trigger Dell Packages Update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          # For token information, see: https://github.com/peter-evans/repository-dispatch/tree/main?tab=readme-ov-file#token
+          token: ${{ secrets.CSMBOT_PAT }}
+          repository: ${{ matrix.repo }}
+          event-type: latest-commits-libraries
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/trigger-update-libraries-to-commits.yml
+++ b/.github/workflows/trigger-update-libraries-to-commits.yml
@@ -22,7 +22,8 @@ jobs:
 
     strategy:
       matrix:
-        # Note: dell-csi-extensions isn't included here because it's handled in its own release action
+        # Note: dell-csi-extensions isn't included here
+        # due to its nested submodules, this automation won't work for it
         repo:
           [
             "dell/cert-csi",

--- a/.github/workflows/update-libraries-to-commits.yml
+++ b/.github/workflows/update-libraries-to-commits.yml
@@ -10,11 +10,7 @@
 name: Update Dell Packages to Latest Commits
 
 on:
-  schedule:
-    - cron: '0 12 * * 1' # Runs every Monday at midnight
   workflow_call:
-  # Can be manually triggered
-  workflow_dispatch:
 
 jobs:
   update-dependencies:

--- a/.github/workflows/update-libraries.yml
+++ b/.github/workflows/update-libraries.yml
@@ -11,8 +11,6 @@ name: Update Dell Packages to Latest Released
 
 on:
   workflow_call:
-  # Can be manually triggered
-  workflow_dispatch:
 
 jobs:
   update-dependencies:

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ on:  # yamllint disable-line rule:truthy
           - patch
 jobs:
   csm-release:
-    uses: dell/common-github-actions/.github/workflows/csm-release-driver-module.yaml@main    
+    uses: dell/common-github-actions/.github/workflows/csm-release-driver-module.yaml@main
     name: Release CSM Drivers and Modules
     with:
       version: ${{ github.event.inputs.option }}
@@ -241,6 +241,8 @@ The workflow does not accept any parameters and can be used from any repository 
 name: Dell Libraries Commit Update
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
+  repository_dispatch:
+    types: [latest-commits-libraries]
 
 jobs:
   library-update:

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -36,11 +36,6 @@ inputs:
     description: 'Name of directory to be excluded from go test'
     required: false
     default: ""
-outputs:
-  coverage:
-    description: 'A summary of the code coverage results meeting the threshold'
-  code_coverage_artifact:
-    description: 'The code coverage report for pull requests'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/go-code-tester/action.yml
+++ b/go-code-tester/action.yml
@@ -36,6 +36,11 @@ inputs:
     description: 'Name of directory to be excluded from go test'
     required: false
     default: ""
+outputs:
+  coverage:
+    description: 'A summary of the code coverage results meeting the threshold'
+  code_coverage_artifact:
+    description: 'The code coverage report for pull requests'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -169,7 +169,7 @@ done
 # Escape newlines and special characters before writing to $GITHUB_OUTPUT
 escaped_coverage=$(cat coverage_results.txt | awk '{printf "%s\\n", $0}')
 echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
-# Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on PRs
+# Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on pull requests
 echo "code_coverage_artifact=$(cat coverage.txt)" >> $GITHUB_OUTPUT
 
 exit ${FAIL}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -133,7 +133,6 @@ for submodule in $submodules; do
 
     coverage_results["$package"]=$coverage
 
-    cat cover.out
     # Append coverage results to combined file for coverage report
     cat cover.out >> coverage.txt
   done

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -133,6 +133,7 @@ for submodule in $submodules; do
 
     coverage_results["$package"]=$coverage
 
+    cat cover.out
     # Append coverage results to combined file for coverage report
     cat cover.out >> coverage.txt > /dev/null
   done

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -133,8 +133,13 @@ for submodule in $submodules; do
 
     coverage_results["$package"]=$coverage
 
+    # Print the current working directory and list files
+    echo "Current directory: $(pwd)"
+    echo "Files in directory:"
+    ls -l
+
     if [ ! -s cover.out ]; then
-    echo "WARNING: coverage.txt is empty or not created for package $package"
+      echo "WARNING: coverage.txt is empty or not created for package $package"
     else
       echo "Contents of coverage.txt:"
       cat cover.out
@@ -180,7 +185,6 @@ done
 escaped_coverage=$(cat coverage_results.txt | awk '{printf "%s\\n", $0}')
 echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
 # Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on pull requests
-cat coverage.txt
 echo "code_coverage_artifact=$(cat coverage.txt)" >> $GITHUB_OUTPUT
 
 exit ${FAIL}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -134,7 +134,7 @@ for submodule in $submodules; do
     coverage_results["$package"]=$coverage
 
     # Append coverage results to combined file for coverage report
-    cat cover.out >> coverage.txt
+    cat cover.out >> coverage.txt > /dev/null
   done
 
   cd - > /dev/null
@@ -172,7 +172,13 @@ done
 # Escape newlines and special characters before writing to $GITHUB_OUTPUT
 escaped_coverage=$(cat coverage_results.txt | awk '{printf "%s\\n", $0}')
 echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
+
 # Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on pull requests
-echo "code_coverage_artifact=$(cat coverage.txt)" >> $GITHUB_OUTPUT
+# echo "code_coverage_artifact=$(cat coverage.txt)" >> $GITHUB_OUTPUT
+{
+  echo "code_coverage_artifact<<EOF"
+  cat coverage.txt
+  echo "EOF"
+} >> $GITHUB_OUTPUT
 
 exit ${FAIL}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -175,13 +175,6 @@ echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
 
 # Below is for the "Upload coverprofile" and "Generate coverage report" steps
 # --------------------------------------------------------------------------
-# Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on pull requests
-# Handle multiline format for $GITHUB_OUTPUT
-# {
-#   echo "code_coverage_artifact<<EOF"
-#   cat coverage.txt
-#   echo "EOF"
-# } >> $GITHUB_OUTPUT
 
 # Process coverage.txt file to keep the first 'mode: atomic' and remove subsequent ones
 awk 'NR==1 || $0 !~ /^mode: atomic$/' coverage.txt > new_coverage.txt

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -173,6 +173,8 @@ done
 escaped_coverage=$(cat coverage_results.txt | awk '{printf "%s\\n", $0}')
 echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
 
+# Below is for the "Upload coverprofile" and "Generate coverage report" steps
+# --------------------------------------------------------------------------
 # Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on pull requests
 # Handle multiline format for $GITHUB_OUTPUT
 # {
@@ -180,6 +182,10 @@ echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
 #   cat coverage.txt
 #   echo "EOF"
 # } >> $GITHUB_OUTPUT
-echo "code_coverage_artifact=coverage.txt" >> $GITHUB_OUTPUT
+
+# Process coverage.txt file to keep the first 'mode: atomic' and remove subsequent ones
+awk 'NR==1 || $0 !~ /^mode: atomic$/' coverage.txt > new_coverage.txt
+# Write to $GITHUB_OUTPUT
+echo "code_coverage_artifact=new_coverage.txt" >> $GITHUB_OUTPUT
 
 exit ${FAIL}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -133,18 +133,6 @@ for submodule in $submodules; do
 
     coverage_results["$package"]=$coverage
 
-    # Print the current working directory and list files
-    echo "Current directory: $(pwd)"
-    echo "Files in directory:"
-    ls -l
-
-    if [ ! -s cover.out ]; then
-      echo "WARNING: coverage.txt is empty or not created for package $package"
-    else
-      echo "Contents of coverage.txt:"
-      cat cover.out
-    fi
-
     # Append coverage results to combined file for coverage report
     cat cover.out >> coverage.txt
   done

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -99,7 +99,7 @@ for submodule in $submodules; do
     # Run go test with coverage for the package
     if [[ -z $RACE_DETECTOR ]] || [[ $RACE_DETECTOR == "true" ]]; then
       # Run with the race flag
-      go_test_cmd="go test $skip_options -v -short -race -count=1 -cover $package $run_options"
+      go_test_cmd="go test $skip_options -v -short -race -count=1 -cover -coverprofile cover.out $package $run_options"
       output=$($go_test_cmd 2>&1)
       TEST_RETURN_CODE=$?
 
@@ -107,7 +107,7 @@ for submodule in $submodules; do
       echo "********** $go_test_cmd **********"
     else
       # Run without the race flag
-      go_test_cmd="go test $skip_options -v -short -count=1 -cover $package $run_options"
+      go_test_cmd="go test $skip_options -v -short -count=1 -cover -coverprofile cover.out $package $run_options"
       output=$($go_test_cmd 2>&1)
       TEST_RETURN_CODE=$?
 

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -132,6 +132,9 @@ for submodule in $submodules; do
     fi
 
     coverage_results["$package"]=$coverage
+
+    # Append coverage results to combined file for coverage report
+    cat cover.out >> coverage.txt
   done
 
   cd - > /dev/null
@@ -170,6 +173,7 @@ done
 escaped_coverage=$(cat coverage_results.txt | awk '{printf "%s\\n", $0}')
 echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
 # Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on pull requests
+cat coverage.txt
 echo "code_coverage_artifact=$(cat coverage.txt)" >> $GITHUB_OUTPUT
 
 exit ${FAIL}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -174,7 +174,7 @@ escaped_coverage=$(cat coverage_results.txt | awk '{printf "%s\\n", $0}')
 echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
 
 # Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on pull requests
-# echo "code_coverage_artifact=$(cat coverage.txt)" >> $GITHUB_OUTPUT
+# Handle multiline format for $GITHUB_OUTPUT
 {
   echo "code_coverage_artifact<<EOF"
   cat coverage.txt

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -135,7 +135,7 @@ for submodule in $submodules; do
 
     cat cover.out
     # Append coverage results to combined file for coverage report
-    cat cover.out >> coverage.txt > /dev/null
+    cat cover.out >> coverage.txt
   done
 
   cd - > /dev/null

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -169,5 +169,7 @@ done
 # Escape newlines and special characters before writing to $GITHUB_OUTPUT
 escaped_coverage=$(cat coverage_results.txt | awk '{printf "%s\\n", $0}')
 echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
+# Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on PRs
+echo "code_coverage_artifact=$(cat coverage.txt)" >> $GITHUB_OUTPUT
 
 exit ${FAIL}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -133,7 +133,7 @@ for submodule in $submodules; do
 
     coverage_results["$package"]=$coverage
 
-    # Append coverage results to combined file for coverage report
+    # Append coverage results to combined file for "Generate coverage report" step
     cat cover.out >> coverage.txt
   done
 
@@ -175,10 +175,11 @@ echo "coverage=$escaped_coverage" >> $GITHUB_OUTPUT
 
 # Write the coverage artifact name to $GITHUB_OUTPUT for code coverage report on pull requests
 # Handle multiline format for $GITHUB_OUTPUT
-{
-  echo "code_coverage_artifact<<EOF"
-  cat coverage.txt
-  echo "EOF"
-} >> $GITHUB_OUTPUT
+# {
+#   echo "code_coverage_artifact<<EOF"
+#   cat coverage.txt
+#   echo "EOF"
+# } >> $GITHUB_OUTPUT
+echo "code_coverage_artifact=coverage.txt" >> $GITHUB_OUTPUT
 
 exit ${FAIL}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -133,6 +133,13 @@ for submodule in $submodules; do
 
     coverage_results["$package"]=$coverage
 
+    if [ ! -s cover.out ]; then
+    echo "WARNING: coverage.txt is empty or not created for package $package"
+    else
+      echo "Contents of coverage.txt:"
+      cat cover.out
+    fi
+
     # Append coverage results to combined file for coverage report
     cat cover.out >> coverage.txt
   done


### PR DESCRIPTION
# Description
- Adds UT coverage report tool. This is an indicator of the quality of changes introduced for a package by showing if package coverage has increased, decreased, or stayed the same.
- Adds coverprofile as a github artifact to the dev branch and main branch
- Adds trigger job for updating golibs to the latest commits. Runs on a cron job to be executed every Sunday

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|  https://github.com/dell/csm/issues/1490        | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested go coverage report on forked repo https://github.com/shaynafinocchiaro/test-gocsi/pull/13
![Screenshot 2025-02-25 212348](https://github.com/user-attachments/assets/b7e41e6e-6970-429a-ac5e-6b71156af45a)
