### PR TITLE
Update gosec action

### DIFF
--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -91,6 +91,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
       - name: gosec
         uses: dell/common-github-actions/gosec-runner@main
         with:

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: gosec
-        uses: dell/common-github-actions/gosec-runner@add-setup-go
+        uses: dell/common-github-actions/gosec-runner@main
         with:
           excludes: ${{ env.GOSEC_EXCLUDES }}
           exclude-dir: ${{ env.GOSEC_EXCLUDE_DIR }}

--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -91,13 +91,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
       - name: gosec
-        uses: dell/common-github-actions/gosec-runner@main
+        uses: dell/common-github-actions/gosec-runner@add-setup-go
         with:
           excludes: ${{ env.GOSEC_EXCLUDES }}
           exclude-dir: ${{ env.GOSEC_EXCLUDE_DIR }}

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -22,7 +22,10 @@ then
   EXCLUDE_DIR_FLAG="-exclude-dir=$EXCLUDE_DIR"
 fi
 
-curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.21.4
+# Fetch the latest version of gosec
+LATEST_VERSION=$(curl -s https://api.github.com/repos/securego/gosec/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $LATEST_VERSION
 echo "run gosec command: $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES"
 $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES
 


### PR DESCRIPTION
# Description
Update gosec to always use the latest released version of gosec to avoid seeing this issue when we update our repositories to the latest go version.
```
Golang errors in file: [-]:

  > [line 0 : column 0] - This application uses version go1.23 of the source-processing packages but runs version go1.24 of 'go list'. It may fail to process source files that rely on newer language features. If so, rebuild the application using a newer version of Go.


Golang errors in file: [/github/workspace/main.go]:

  > [line 1 : column 1] - package requires newer Go version go1.24 (application built with go1.23)
```
  
# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|   https://github.com/dell/csm/issues/1747       | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] https://github.com/dell/csi-powerscale/actions/runs/13724632033/job/38388018990?pr=356
