### PR TITLE
Exclude generated code from being processed by gosec

### DIFF
--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -27,7 +27,7 @@ LATEST_VERSION=$(curl -s https://api.github.com/repos/securego/gosec/releases/la
 
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $LATEST_VERSION
 echo "run gosec command: $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES"
-$(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES
+$(go env GOPATH)/bin/gosec -exclude-generated $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES
 
 TEST_RETURN_CODE=$?
 if [ "${TEST_RETURN_CODE}" != "0" ]; then

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 LATEST_VERSION=$(curl -s https://api.github.com/repos/securego/gosec/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $LATEST_VERSION
-echo "run gosec command: $(go env GOPATH)/bin/gosec $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES"
+echo "run gosec command: $(go env GOPATH)/bin/gosec -exclude-generated $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES"
 $(go env GOPATH)/bin/gosec -exclude-generated $EXCLUDE_FLAG $EXCLUDE_DIR_FLAG $DIRECTORIES
 
 TEST_RETURN_CODE=$?


### PR DESCRIPTION
# Description
Update the `gosec` action to include the `-exclude-generated` flag. This will bypass checking any file that has been generated by some generator.

See: https://github.com/securego/gosec?tab=readme-ov-file#excluding-generated-files

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/csm/issues/1747 | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensured that `gosec` successfully ignores generated code that previously detected issues.
- [x] Ensured that fixes work as expected (https://github.com/dell/csm-hbnfs/actions/runs/13947668363/job/39038627815?pr=9).
 
