### PR TITLE
Release Branch Step - Check For Existing Branch

### DIFF
--- a/.github/workflows/release-creator.yaml
+++ b/.github/workflows/release-creator.yaml
@@ -39,21 +39,21 @@ jobs:
         run: |
           current_version=$MY_VAR
           current_version=(${current_version#v}) # remove 'v' prefix from $current_version"
-          
+
           IFS='.' read -r -a version_parts <<< "$current_version"              
-          
+
           if "${{ inputs.version == 'major' }}"; then
               # major version bump up
               version_parts[0]=$(expr ${version_parts[0]} + 1)
               new_version="${version_parts[0]}.0.0"
           fi
-          
+
           if "${{ inputs.version == 'minor' }}"; then
               # minor version bump up
               version_parts[1]=$(expr ${version_parts[1]} + 1)
               new_version="${version_parts[0]}.${version_parts[1]}.0"
           fi
-          
+
           if "${{ inputs.version == 'patch' }}"; then
               # patch version bump up
               version_parts[2]=$(expr ${version_parts[2]} + 1)
@@ -82,15 +82,15 @@ jobs:
 
       - name: Download binary
         uses: actions/download-artifact@v4.2.1
-  
+
       # This is required to check if the binary exists and update its name to the release.
-      - run: |            
-            FILE="./cert-csi-linux-amd64/cert-csi-linux-amd64"
-            if [ -d "repctl-linux-amd64" ]; then
-                FILE="./repctl-linux-amd64/repctl-linux-amd64"
-            fi
-            echo "File name: $FILE"
-            echo "FILE_NAME=$FILE" >> $GITHUB_ENV
+      - run: |
+          FILE="./cert-csi-linux-amd64/cert-csi-linux-amd64"
+          if [ -d "repctl-linux-amd64" ]; then
+              FILE="./repctl-linux-amd64/repctl-linux-amd64"
+          fi
+          echo "File name: $FILE"
+          echo "FILE_NAME=$FILE" >> $GITHUB_ENV
         shell: bash
 
       - name: Create Release
@@ -112,5 +112,12 @@ jobs:
         env:
           REL_VERSION: ${{ env.REL_VERSION }}
         run: |
-          git checkout -b release/$REL_VERSION
-          git push origin release/$REL_VERSION
+          branch_name="release/$REL_VERSION"
+          git fetch origin
+          if git ls-remote --heads origin $branch_name | grep $branch_name; then
+            echo "Branch name $branch_name already exists. Skipping branch creation."
+            git checkout $branch_name
+          else
+            git checkout -b $branch_name
+            git push origin $branch_name
+          fi


### PR DESCRIPTION
# Description
Presently, the release action causes a failure if the branch for a release already exists, which will always be the case with our standard patch workflow. This PR makes the release action check if the branch already exists, and if it does, notes as such but does not induce a failure. 

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|     https://github.com/dell/csm/issues/1811     | 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A)
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A)

# How Has This Been Tested?
Tested in a forked repository [with successful run here.](https://github.com/shaynafinocchiaro/test-csm-operator/actions/runs/14045285835/job/39324634594)
