### PR TITLE
Update go-code-tester for excluded directories

### DIFF
--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run unit tests and check package coverage
         id: test_coverage
-        uses: dell/common-github-actions/go-code-tester@minor-fix
+        uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: ${{ env.CODE_COVERAGE_TARGET }}
           test-folder: ${{ env.CODE_COVERAGE_DIR }}

--- a/go-code-tester/entrypoint.sh
+++ b/go-code-tester/entrypoint.sh
@@ -78,10 +78,8 @@ check_coverage() {
 if [ -n "$EXCLUDE_DIRECTORIES" ]; then
     EXCLUDED_PATHS=$(echo "$EXCLUDE_DIRECTORIES" | sed 's/|/\/\*\" -not -path \"/g' | sed 's/^/-not -path \"/' | sed 's/$/\/\*\"/')
     submodules=$(eval find . -name 'go.mod' "$EXCLUDED_PATHS" -exec dirname {} +)
-    echo "Found submodules: $submodules"
 else
     submodules=$(find . -name 'go.mod' -exec dirname {} +)
-    echo "Found submodules: $submodules"
 fi
 
 # Submodules may not exist if testing in a specific TEST_FOLDER


### PR DESCRIPTION
# Description
This PR #146 highlighted an issue with the go-code-tester script where directories were not being excluded from the list of submodules. Previously, this wasn't a problem because go list would return nothing, resulting in no packages for unit testing. However, the introduction of error checking brought this oversight to light.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|    https://github.com/dell/csm/issues/1490      | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested with multiple excluded directories - https://github.com/shaynafinocchiaro/test-csm-operator/actions/runs/14361329509/job/40269343936
- [x] Tested with one excluded directory - https://github.com/dell/csi-powerflex/actions/runs/14361165922/job/40268975828?pr=450
- [x] Tested no excluded directories and still catches go mod tidy errors - https://github.com/shaynafinocchiaro/test-csm-replication/actions/runs/14361130446/job/40269553736
