### PR TITLE
Exclude binary files from go workflow

### DIFF
--- a/.github/workflows/go-static-analysis.yaml
+++ b/.github/workflows/go-static-analysis.yaml
@@ -84,3 +84,23 @@ jobs:
             echo "No Yamllint config file found, running with defaults"
             yamllint .
           fi
+
+  # Check Dockerfiles for errors
+  dockerfile_lint:
+    name: Dockerfile Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+      - name: Run Hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+
+  # Check shell scripts for syntax, bugs, etc.
+  shell_lint:
+    name: Shell Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+      - name: Run Shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/go-static-analysis.yaml
+++ b/.github/workflows/go-static-analysis.yaml
@@ -84,23 +84,3 @@ jobs:
             echo "No Yamllint config file found, running with defaults"
             yamllint .
           fi
-
-  # Check Dockerfiles for errors
-  dockerfile_lint:
-    name: Dockerfile Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the code
-        uses: actions/checkout@v4
-      - name: Run Hadolint
-        uses: hadolint/hadolint-action@v3.1.0
-
-  # Check shell scripts for syntax, bugs, etc.
-  shell_lint:
-    name: Shell Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the code
-        uses: actions/checkout@v4
-      - name: Run Shellcheck
-        uses: ludeeus/action-shellcheck@2.0.0

--- a/.github/workflows/go-version-workflow.yaml
+++ b/.github/workflows/go-version-workflow.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Update go version
         env:
           gomod: go.mod
-          grep_cmd2: grep -l "go-version"
+          grep_cmd2: grep --exclude-dir=.git -l "go-version"
           grep_cmd3: grep -l "FROM golang"
           exclude_file: go-version-workflow.yaml
         run: |
@@ -64,7 +64,7 @@ jobs:
           fi
           echo "here 1"
 
-          find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && grep --exclude-dir=.git -q "toolchain" go.mod && go mod edit -toolchain ${{ env.latest_version }} && go mod tidy' \;
+          find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && grep -q "toolchain" go.mod && go mod edit -toolchain ${{ env.latest_version }} && go mod tidy' \;
           if [ $? -ne 0 ]; then
             echo "Failed to update toolchain"
             exit 1

--- a/.github/workflows/go-version-workflow.yaml
+++ b/.github/workflows/go-version-workflow.yaml
@@ -62,12 +62,15 @@ jobs:
             echo "Failed to update go.mod"
             exit 1
           fi
+          echo "here 1"
 
-          find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && grep -q "toolchain" go.mod && go mod edit -toolchain ${{ env.latest_version }} && go mod tidy' \;
+          find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && grep --exclude-dir=.git -q "toolchain" go.mod && go mod edit -toolchain ${{ env.latest_version }} && go mod tidy' \;
           if [ $? -ne 0 ]; then
             echo "Failed to update toolchain"
             exit 1
           fi
+
+          echo "here 2"
 
           if [ -f config/csm-common.mk ]; then sed -i "s/^DEFAULT_GOVERSION.*/DEFAULT_GOVERSION=${{ env.major_version }}/g" config/csm-common.mk; fi
           if [ $? -ne 0 ]; then
@@ -75,17 +78,23 @@ jobs:
             exit 1
           fi
 
+          echo "here 3"
+
           find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd2 }} {} \; | while read -r file; do grep -v "hugo-version" "$file" | sed -i "s/go-version:.*/go-version: \"${{ env.major_version }}\"/" "$file"; done
           if [ $? -ne 0 ]; then
             echo "Failed to update github actions"
             exit 1
           fi
 
+          echo "here 4"
+
           find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd3 }} {} \; | while read -r file; do sed -i "s/golang:.*/golang:${{ env.major_version }}/" "$file"; done
           if [ $? -ne 0 ]; then
             echo "Failed to update dockerfiles"
             exit 1
           fi
+
+          echo "here 5"
 
       # Needed for signing commits using Github App tokens
       # See: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signing

--- a/.github/workflows/go-version-workflow.yaml
+++ b/.github/workflows/go-version-workflow.yaml
@@ -51,48 +51,37 @@ jobs:
       - name: Update go version
         env:
           gomod: go.mod
-          grep_cmd2: grep --exclude-dir=.git -l "go-version"
+          grep_cmd2: grep -I -l "go-version"
           grep_cmd3: grep -l "FROM golang"
           exclude_file: go-version-workflow.yaml
         run: |
           echo "Updating go version to ${{ env.major_version }}"
 
           find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && go mod edit -go ${{ env.major_version }} && go mod tidy' \;
-          if [ $? -ne 0 ]; then
-            echo "Failed to update go.mod"
-            exit 1
-          fi
+
           echo "here 1"
 
           find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && grep -q "toolchain" go.mod && go mod edit -toolchain ${{ env.latest_version }} && go mod tidy' \;
-          if [ $? -ne 0 ]; then
-            echo "Failed to update toolchain"
-            exit 1
-          fi
 
           echo "here 2"
 
-          if [ -f config/csm-common.mk ]; then sed -i "s/^DEFAULT_GOVERSION.*/DEFAULT_GOVERSION=${{ env.major_version }}/g" config/csm-common.mk; fi
-          if [ $? -ne 0 ]; then
-            echo "Failed to update config/csm-common.mk"
-            exit 1
+          if [ -f config/csm-common.mk ]; then
+            sed -i "s/^DEFAULT_GOVERSION.*/DEFAULT_GOVERSION=${{ env.major_version }}/g" config/csm-common.mk;
           fi
 
           echo "here 3"
 
-          find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd2 }} {} \; | while read -r file; do grep -v "hugo-version" "$file" | sed -i "s/go-version:.*/go-version: \"${{ env.major_version }}\"/" "$file"; done
-          if [ $? -ne 0 ]; then
-            echo "Failed to update github actions"
-            exit 1
-          fi
+          find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd2 }} {} + | while read -r file;
+          do
+            grep -v "hugo-version" "$file" | sed -i "s/go-version:.*/go-version: \"${{ env.major_version }}\"/" "$file";
+          done
 
           echo "here 4"
 
-          find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd3 }} {} \; | while read -r file; do sed -i "s/golang:.*/golang:${{ env.major_version }}/" "$file"; done
-          if [ $? -ne 0 ]; then
-            echo "Failed to update dockerfiles"
-            exit 1
-          fi
+          find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd3 }} {} \; | while read -r file;
+          do
+            sed -i "s/golang:.*/golang:${{ env.major_version }}/" "$file";
+          done
 
           echo "here 5"
 

--- a/.github/workflows/go-version-workflow.yaml
+++ b/.github/workflows/go-version-workflow.yaml
@@ -59,31 +59,21 @@ jobs:
 
           find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && go mod edit -go ${{ env.major_version }} && go mod tidy' \;
 
-          echo "here 1"
-
           find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && grep -q "toolchain" go.mod && go mod edit -toolchain ${{ env.latest_version }} && go mod tidy' \;
-
-          echo "here 2"
 
           if [ -f config/csm-common.mk ]; then
             sed -i "s/^DEFAULT_GOVERSION.*/DEFAULT_GOVERSION=${{ env.major_version }}/g" config/csm-common.mk;
           fi
-
-          echo "here 3"
 
           find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd2 }} {} + | while read -r file;
           do
             grep -v "hugo-version" "$file" | sed -i "s/go-version:.*/go-version: \"${{ env.major_version }}\"/" "$file";
           done
 
-          echo "here 4"
-
           find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd3 }} {} \; | while read -r file;
           do
             sed -i "s/golang:.*/golang:${{ env.major_version }}/" "$file";
           done
-
-          echo "here 5"
 
       # Needed for signing commits using Github App tokens
       # See: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signing

--- a/.github/workflows/go-version-workflow.yaml
+++ b/.github/workflows/go-version-workflow.yaml
@@ -58,14 +58,34 @@ jobs:
           echo "Updating go version to ${{ env.major_version }}"
 
           find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && go mod edit -go ${{ env.major_version }} && go mod tidy' \;
+          if [ $? -ne 0 ]; then
+            echo "Failed to update go.mod"
+            exit 1
+          fi
 
           find . -type f -name "${{ env.gomod }}" -execdir sh -c '[ -f "{}" ] && grep -q "toolchain" go.mod && go mod edit -toolchain ${{ env.latest_version }} && go mod tidy' \;
+          if [ $? -ne 0 ]; then
+            echo "Failed to update toolchain"
+            exit 1
+          fi
 
           if [ -f config/csm-common.mk ]; then sed -i "s/^DEFAULT_GOVERSION.*/DEFAULT_GOVERSION=${{ env.major_version }}/g" config/csm-common.mk; fi
+          if [ $? -ne 0 ]; then
+            echo "Failed to update config/csm-common.mk"
+            exit 1
+          fi
 
           find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd2 }} {} \; | while read -r file; do grep -v "hugo-version" "$file" | sed -i "s/go-version:.*/go-version: \"${{ env.major_version }}\"/" "$file"; done
+          if [ $? -ne 0 ]; then
+            echo "Failed to update github actions"
+            exit 1
+          fi
 
           find . -type f ! -name "${{ env.exclude_file }}" -exec ${{ env.grep_cmd3 }} {} \; | while read -r file; do sed -i "s/golang:.*/golang:${{ env.major_version }}/" "$file"; done
+          if [ $? -ne 0 ]; then
+            echo "Failed to update dockerfiles"
+            exit 1
+          fi
 
       # Needed for signing commits using Github App tokens
       # See: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#commit-signing


### PR DESCRIPTION
# Description
- Adds -I to grep to exclude binary files from being picked up when updating "go-version" references
`grep: ./.git/index: binary file matches
`
# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|   https://github.com/dell/csm/issues/1490       | 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested forked gocsi https://github.com/shaynafinocchiaro/test-gocsi/actions/runs/14608442931/job/40981892187
- [x] Tested forked csi-powerflex https://github.com/shaynafinocchiaro/test-csi-powerflex/actions/runs/14608450563/job/40981913549
