### PR TITLE
Properly Sanitize CSM Version

### DIFF
--- a/.github/workflows/csi-sidecars-update.yaml
+++ b/.github/workflows/csi-sidecars-update.yaml
@@ -90,10 +90,14 @@ jobs:
           }
 
           update_installation_wizard_sidecars() {
-            csm_version=$csm
+            # Get the latest CSM version
+            echo "Latest CSM Version is $csm"
+
+            # Sanitize the CSM version
+            csm_version=$(echo $csm | tr -d 'v' | tr -d '\r')
 
             # The installation wizard templates should have the latest version of the CSM.
-            wizard_files=$(find content/docs/getting-started/installation/installationwizard/src/templates/ -name "*$version*")
+            wizard_files=$(find content/docs/getting-started/installation/installationwizard/src/templates/ -name "*$csm_version*")
 
             if [ -z "$wizard_files" ]; then
               echo "No Installation Wizard content for latest CSM found. Skipping."


### PR DESCRIPTION
# Description
After further testing, it was highlighted that the bash parsing of the variable had extra characters that needed to be sanitized before performing a search and using it as a string literal.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|          | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran action and ensured that the CSM Version is now properly stripped to be used as a string for file matching.
![image](https://github.com/user-attachments/assets/47470212-e0c2-4230-875f-dc4bd72a5a59)