### PR TITLE
Add gosec dependency installation

### DIFF
--- a/.github/workflows/go-common.yml
+++ b/.github/workflows/go-common.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: gosec
+      - name: Run Gosec
         uses: dell/common-github-actions/gosec-runner@main
         with:
           excludes: ${{ env.GOSEC_EXCLUDES }}

--- a/gosec-runner/Dockerfile
+++ b/gosec-runner/Dockerfile
@@ -7,6 +7,8 @@ LABEL "com.github.actions.color"="gray-dark"
 
 LABEL version="1.0.0"
 
+RUN go install github.com/securego/gosec/v2/cmd/gosec@latest
+
 ENV GOFLAGS="-buildvcs=false"
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/gosec-runner/entrypoint.sh
+++ b/gosec-runner/entrypoint.sh
@@ -39,11 +39,6 @@ get_exclude_directories() {
     EXCLUDE_DIR_FLAG="$exclude_arg"
 }
 
-# Fetch the latest version of gosec
-LATEST_VERSION=$(curl -s https://api.github.com/repos/securego/gosec/releases/latest | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-
-curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $LATEST_VERSION
-
 submodules=$(find . -name 'go.mod' -exec dirname {} +)
 for submodule in $submodules; do
   echo "Running gosec on $submodule"


### PR DESCRIPTION
# Description
Change the installation of `gosec` from curl to specifically `go install`. This is an attempt to avoid the rate limit within GitHub which is causing the test to fail.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|          | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested to ensure that gosec test doesn't fail.
![image](https://github.com/user-attachments/assets/7a078d29-d72a-430d-9712-92914c8abf09)
