### PR TITLE
Add check for not existing release version

### DIFF
--- a/.github/workflows/release-creator.yaml
+++ b/.github/workflows/release-creator.yaml
@@ -48,6 +48,12 @@ jobs:
           MY_VAR: ${{ env.MY_VAR }}
         run: |
           current_version=$MY_VAR
+
+          # The latest version does not exist. Set it to v0.0.0.
+          if [[ "$current_version" = "null" ]]; then
+            current_version="v0.0.0"
+          fi
+
           current_version=(${current_version#v}) # remove 'v' prefix from $current_version"
 
           IFS='.' read -r -a version_parts <<< "$current_version"              


### PR DESCRIPTION
# Description
An issue was identified where, if the repository was cutting it's first initial release, the release creator would fail due to the retrieval of releases returning `null`. This causes issues with new repositories and forces the developers to manually cut a release which could be error prone.

**Fix:** Check the response of the `curl` command and if it returns that there is no release, set the version to be `v0.0.0`. This allows the rest of the action to work as expected since it will automatically increment the version.

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
| https://github.com/dell/csm/issues/1490 | 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested to ensure that initial releases work in a similar manner as other every other release.
<img width="484" height="119" alt="image" src="https://github.com/user-attachments/assets/601b2f4d-02d8-4d06-89ee-ad2c7bf40843" />
