### PR TITLE
Update Release Workflow

### DIFF
--- a/.github/workflows/create-tag-release.yaml
+++ b/.github/workflows/create-tag-release.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Dell Inc., or its subsidiaries. All Rights Reserved.
+# Copyright (c) 2025 Dell Inc., or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description
I've split the release workflow into two distinct parts:

- Create Tag and Release
- Release Image

This change was made to address an issue in the previous workflow where images were being released with incorrect semantic versioning. By separating the workflows, we now:

- First, create the release tag.
- Then, manually rebuild the nightly image to ensure it includes the correct semver version.
- Finally, trigger the Release Image workflow, which now reliably publishes images with the correct version.


# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|https://github.com/dell/csm/issues/1995 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
This is tested in forked repo, created the tag and release, pushed the images to test quay folder

<img width="644" height="111" alt="create tag" src="https://github.com/user-attachments/assets/c078b325-24a0-4988-8586-307ab4ebb0b7" />

<img width="426" height="134" alt="release " src="https://github.com/user-attachments/assets/711b3729-533b-4eeb-90ea-b6ef2baf5125" />

