### PR TITLE
Update repository path in release-image.yaml

### DIFF
--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -32,7 +32,7 @@ jobs:
         shell: bash
         run: |
           images_list=$(echo '${{ inputs.images }}' | tr -d '[]"' | tr ',' ' ')
-          REPOSITORY="delltech/csm"
+          REPOSITORY="dell/container-storage-modules"
 
           for image in $images_list; do
             latest_version=$(curl -s https://quay.io/api/v1/repository/$REPOSITORY/$image/tag/?limit=100 | jq -r '.tags[].name' | sort -V | tail -n 1)


### PR DESCRIPTION
# Description
I have reverted the repository path to production image repository.

https://github.com/dell/common-github-actions/blob/20335b9e046de30c4d12a4421812961edde47401/.github/workflows/csm-release-driver-module.yaml#L86

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|https://github.com/dell/csm/issues/1995

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

