### PR TITLE
Update quay retrieval of latest image

### DIFF
--- a/.github/workflows/csm-release-driver-module.yaml
+++ b/.github/workflows/csm-release-driver-module.yaml
@@ -87,7 +87,7 @@ jobs:
 
           for image in $images_list; do
 
-            latest_version=$(curl -s https://quay.io/api/v1/repository/$REPOSITORY/$image/tag/?limit=100 | jq -r '.tags[].name' | sort -V | tail -n 1)
+            latest_version=$(curl -s https://quay.io/api/v1/repository/$REPOSITORY/$image?tab=tags | jq -r '.tags[].name' | sort -V | tail -n 1)
             echo "Current latest version of $image:$latest_version"
 
             IFS='.' read -r -a version_parts <<< "$latest_version"

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -35,7 +35,7 @@ jobs:
           REPOSITORY="dell/container-storage-modules"
 
           for image in $images_list; do
-            latest_version=$(curl -s https://quay.io/api/v1/repository/$REPOSITORY/$image/tag/?limit=100 | jq -r '.tags[].name' | sort -V | tail -n 1)
+            latest_version=$(curl -s https://quay.io/api/v1/repository/$REPOSITORY/$image?tab=tags | jq -r '.tags[].name' | sort -V | tail -n 1)
             echo "Current latest version of $image:$latest_version"
 
             IFS='.' read -r -a version_parts <<< "$latest_version"


### PR DESCRIPTION
# Description
During the recent release cycle, the retrieval of repository images from quay were not returning the correct name.

```
$ curl -s https://quay.io/api/v1/repository/dell/container-storage-modules/csm-metrics-powerflex/tag/\?limit\=100 | jq -r '.tags[].name' | sort -V | tail -n 1
sha256-fcab1c2ba2c5050f7615487f66082ea99381ab8bb865525d6cfcb0ab572af0c9.sig
```

For this reason, we updated the path to retrieve the tags in a different manner which should work for all quay repos.
```
$ curl -s https://quay.io/api/v1/repository/dell/container-storage-modules/csm-metrics-powerflex\?tab\=tags | jq -r '.tags[].name' | sort -V | tail -n 1
v1.12.0
```

# Issues
List the issues impacted by this PR:

| Issue ID |
| -------- |
|          | 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested manually to ensure that curls retrieve the correct image version.
- [x] Tested to ensure that this retrieval works through an action: https://github.com/dell/csm-metrics-powermax/actions/runs/17808346930/job/50625647848
